### PR TITLE
fix: vowifi pcscf runtime

### DIFF
--- a/Dockerfile.github
+++ b/Dockerfile.github
@@ -93,6 +93,7 @@ LABEL org.opencontainers.image.title="HiDeck" \
 # - psmisc: 提供 fuser，用于安全释放串口占用
 RUN apk add --no-cache \
       ca-certificates \
+      gcompat \
       lame-libs \
       opencore-amr \
       psmisc \

--- a/third_party/vowifi-go/engine/swu/state_auth.go
+++ b/third_party/vowifi-go/engine/swu/state_auth.go
@@ -676,6 +676,22 @@ func parseAssignedInnerConfig(payloads []ikev2.Payload) (assignedInnerConfig, er
 	if err != nil {
 		return result, err
 	}
+
+	// T-Mobile 可能通过 3GPP 私有属性 16390 下发 IPv6 P-CSCF。
+	// 通用 IKE 解析器支持该属性，但 SWu 会话原本没有复制它。
+	if raw, ok := cpAttributeValue(cp, ikev2.ASSIGNED_PCSCF_IP6_ADDRESS); ok {
+		if len(raw) != net.IPv6len {
+			return result, fmt.Errorf(
+				"swu: invalid assigned P-CSCF IPv6 length %d",
+				len(raw),
+			)
+		}
+		result.pcscf = append(
+			result.pcscf,
+			append(net.IP(nil), raw...),
+		)
+	}
+	
 	if result.ipv4 == nil && result.ipv6 == nil {
 		return result, fmt.Errorf("swu: CFG_REPLY omitted an assigned address (attributes=%s)", cpAttributeSummary(cp))
 	}


### PR DESCRIPTION
## Summary

Parse the IPv6 P-CSCF returned through private-use IKE configuration
attribute 16390 and make it available to the IMS runtime.

## Problem

Some T-Mobile/RedPocket ePDGs return the IPv6 P-CSCF using attribute
16390 instead of the standard `P_CSCF_IP6_ADDRESS` attribute.

The SWu client requested this attribute, and the generic CP parser
recognized it, but `parseAssignedInnerConfig` did not copy it into the
assigned P-CSCF list. IMS therefore fell back to resolving the default
IMS domain through system DNS and registration failed.

## Verification

Before:

- IMS fell back to the default registrar domain.
- Registrar DNS resolution failed.

After:

- The tunnel-provided private IPv6 P-CSCF was selected.
- IMS secure signaling was established.
- IMS REGISTER returned 200.
- IMS SIP keepalive was established.

Tested with a RedPocket GSMA/T-Mobile-profile SIM.
Subscriber identifiers have been omitted.