### PR TITLE
fix(phone): preserve fixed WebRTC UDP port in public ICE candidate

### DIFF
--- a/internal/phone/media.go
+++ b/internal/phone/media.go
@@ -110,7 +110,7 @@ func setWebRTCPublicHost(settings *webrtc.SettingEngine, value string, lookup pu
 	}
 	if err := settings.SetICEAddressRewriteRules(webrtc.ICEAddressRewriteRule{
 		External:        publicIPs,
-		AsCandidateType: webrtc.ICECandidateTypeSrflx,
+		AsCandidateType: webrtc.ICECandidateTypeHost,
 		Mode:            webrtc.ICEAddressRewriteAppend,
 	}); err != nil {
 		return fmt.Errorf("phone: configure WebRTC public host: %w", err)


### PR DESCRIPTION
## Problem

When HiDeck runs behind NAT with a fixed WebRTC UDP port, the configured
public host is currently published as a server-reflexive candidate.

Pion creates that candidate using an ephemeral UDP socket, causing the
advertised public port to differ from `server.webrtc_udp_address`.

For example:

- Configured/listening port: `17581`
- Advertised candidate: `public-ip:38414`

LAN clients can connect through the private host candidate, but cellular
clients cannot reach the randomly advertised port because only the fixed
UDP port is forwarded by the router.

This leaves ICE in `checking`, DTLS never starts, and browser audio is
unavailable.

## Fix

Publish the configured public address as an appended host candidate
instead of a server-reflexive candidate.

This preserves both candidates:

- Private host candidate for LAN clients
- Public host candidate using the same fixed UDP port for Internet clients

## Verification

Tested with:

- WebRTC UDP listener bound to `192.168.10.112:17581`
- Public `17581/UDP` forwarded to the HiDeck server
- LAN browser calling
- Mobile browser calling over cellular data

Both LAN and cellular calls establish ICE/DTLS and have working audio.