### PR TITLE
fix(docker): include qmi proxy runtime dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,10 +92,12 @@ LABEL org.opencontainers.image.title="HiDeck" \
 # - opencore-amr / vo-amrwbenc: AMR 与 AMR-WB 实时编解码
 # - lame-libs: 双向混音录音的 MP3 编码
 # - psmisc: 提供 fuser，用于安全释放串口占用
+# - libqmi: 提供 QMI Proxy 模式所需的 /usr/libexec/qmi-proxy
 RUN apk add --no-cache \
       ca-certificates \
       gcompat \
       lame-libs \
+      libqmi \
       opencore-amr \
       psmisc \
       tzdata \
@@ -103,7 +105,9 @@ RUN apk add --no-cache \
     test -e /usr/lib/libopencore-amrnb.so.0 && \
     test -e /usr/lib/libopencore-amrwb.so.0 && \
     test -e /usr/lib/libvo-amrwbenc.so.0 && \
-    test -e /usr/lib/libmp3lame.so.0
+    test -e /usr/lib/libmp3lame.so.0 && \
+    test -x /usr/libexec/qmi-proxy && \
+    /usr/libexec/qmi-proxy --version
 
 # 管理 HTTP、电话 HTTPS、WebRTC UDP mux
 EXPOSE 7575/tcp 7576/tcp 7580/udp

--- a/Dockerfile.github
+++ b/Dockerfile.github
@@ -91,10 +91,12 @@ LABEL org.opencontainers.image.title="HiDeck" \
 # - opencore-amr / vo-amrwbenc: AMR 与 AMR-WB 实时编解码
 # - lame-libs: 双向混音录音的 MP3 编码
 # - psmisc: 提供 fuser，用于安全释放串口占用
+# - libqmi: 提供 QMI Proxy 模式所需的 /usr/libexec/qmi-proxy
 RUN apk add --no-cache \
       ca-certificates \
       gcompat \
       lame-libs \
+      libqmi \
       opencore-amr \
       psmisc \
       tzdata \
@@ -102,7 +104,9 @@ RUN apk add --no-cache \
     test -e /usr/lib/libopencore-amrnb.so.0 && \
     test -e /usr/lib/libopencore-amrwb.so.0 && \
     test -e /usr/lib/libvo-amrwbenc.so.0 && \
-    test -e /usr/lib/libmp3lame.so.0
+    test -e /usr/lib/libmp3lame.so.0 && \
+    test -x /usr/libexec/qmi-proxy && \
+    /usr/libexec/qmi-proxy --version
 
 # 管理 HTTP、电话 HTTPS、WebRTC UDP mux
 EXPOSE 7575/tcp 7576/tcp 7580/udp

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -7,10 +7,12 @@ WORKDIR /app
 # lame-libs：MP3 录音
 # psmisc：fuser，释放串口
 # gcompat：UPX 压缩后的 Go 二进制在 musl 上需要
+# libqmi：提供 QMI Proxy 模式所需的 /usr/libexec/qmi-proxy
 RUN apk add --no-cache \
       ca-certificates \
       gcompat \
       lame-libs \
+      libqmi \
       opencore-amr \
       psmisc \
       tzdata \
@@ -19,6 +21,8 @@ RUN apk add --no-cache \
     test -e /usr/lib/libopencore-amrwb.so.0 && \
     test -e /usr/lib/libvo-amrwbenc.so.0 && \
     test -e /usr/lib/libmp3lame.so.0 && \
+    test -x /usr/libexec/qmi-proxy && \
+    /usr/libexec/qmi-proxy --version && \
     mkdir -p /app/config /app/data /app/logs
 
 EXPOSE 7575/tcp 7576/tcp 7580/udp


### PR DESCRIPTION
## Summary

Fix Docker images missing `qmi-proxy` while HiDeck is configured to use QMI Proxy mode without falling back to raw `/dev/cdc-wdm*` access.

## Problem

When no external proxy is listening, HiDeck attempts to start:

```text
/usr/libexec/qmi-proxy