### PR TITLE
fix(vowifi): only refresh outbound bindings when required

### DIFF
--- a/third_party/vowifi-go/internal/vowifi/imscore/register.go
+++ b/third_party/vowifi-go/internal/vowifi/imscore/register.go
@@ -127,6 +127,7 @@ func (s *Service) registerLocked(ctx context.Context) error {
 		s.signalingFailureReason = err.Error()
 		s.sipOutboundKeepalive = false
 		s.sipOutbound = false
+		s.outboundBindingRequired = false
 		s.outboundContactOffered = false
 		s.outboundContactRegistered = false
 		s.flowTimer = 0
@@ -726,7 +727,7 @@ func (s *Service) needsOutboundBindingRefresh() bool {
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.sipOutbound && !s.outboundContactRegistered
+	return s.sipOutbound && s.outboundBindingRequired && !s.outboundContactRegistered
 }
 
 func withOutboundContactParams(order []string) []string {

--- a/third_party/vowifi-go/internal/vowifi/imscore/register_flow_trace.go
+++ b/third_party/vowifi-go/internal/vowifi/imscore/register_flow_trace.go
@@ -26,6 +26,9 @@ func (s *Service) logRegisterFlowNegotiation(response *sipResponse) {
 	s.mu.Lock()
 	s.sipOutboundKeepalive = requiredOutbound || viaKeep
 	s.sipOutbound = supportedOutbound || requiredOutbound || pathOB || contactRegID
+	// Supported: outbound advertises a capability only. A follow-up REGISTER
+	// with reg-id/ob is required only when the network explicitly asks for it.
+	s.outboundBindingRequired = requiredOutbound || pathOB || contactRegID
 	if s.outboundContactOffered {
 		s.outboundContactRegistered = true
 	}

--- a/third_party/vowifi-go/internal/vowifi/imscore/register_flow_trace_test.go
+++ b/third_party/vowifi-go/internal/vowifi/imscore/register_flow_trace_test.go
@@ -24,3 +24,28 @@ func TestContainsSIPParameter(t *testing.T) {
 		t.Fatal("partial Contact parameter was accepted")
 	}
 }
+
+func TestSupportedOutboundDoesNotRequireBindingRefresh(t *testing.T) {
+	service := &Service{}
+	service.logRegisterFlowNegotiation(&sipResponse{
+		StatusCode: 200,
+		Headers:    map[string]string{"Supported": "path, sec-agree, outbound"},
+	})
+	if !service.sipOutbound {
+		t.Fatal("Supported: outbound capability was not recorded")
+	}
+	if service.needsOutboundBindingRefresh() {
+		t.Fatal("Supported: outbound alone must not trigger a follow-up REGISTER")
+	}
+}
+
+func TestRequiredOutboundRequiresBindingRefresh(t *testing.T) {
+	service := &Service{}
+	service.logRegisterFlowNegotiation(&sipResponse{
+		StatusCode: 200,
+		Headers:    map[string]string{"Require": "outbound"},
+	})
+	if !service.needsOutboundBindingRefresh() {
+		t.Fatal("Require: outbound must trigger a follow-up REGISTER")
+	}
+}

--- a/third_party/vowifi-go/internal/vowifi/imscore/types.go
+++ b/third_party/vowifi-go/internal/vowifi/imscore/types.go
@@ -212,6 +212,7 @@ type Service struct {
 	tcpCRLFPongWait           time.Duration
 	sipOutboundKeepalive      bool
 	sipOutbound               bool
+	outboundBindingRequired   bool
 	outboundContactOffered    bool
 	outboundContactRegistered bool
 	flowTimer                 time.Duration


### PR DESCRIPTION
## 修复内容

部分运营商仅使用 `Supported: outbound` 表示支持该能力，并不要求额外注册。

此前会错误地额外发送一次带 `reg-id` / `ob` 的 REGISTER；2degrees NZ 会返回 `503`，导致 IMS/SMS 失败。

现在仅在 `Require: outbound`、`Path;ob` 或响应 Contact 含 `reg-id` 时才额外注册。

## 测试

已在 2degrees NZ 实测：CSeq 3 收到 `200 OK` 后，IMS/SMS 正常就绪。

未使用其他运营商 SIM 卡测试，请您协助验证兼容性。