### PR TITLE
fix(vowifi): keep registration after portS closure

### DIFF
--- a/third_party/vowifi-go/internal/vowifi/imscore/register_transport.go
+++ b/third_party/vowifi-go/internal/vowifi/imscore/register_transport.go
@@ -13,11 +13,6 @@ import (
 
 const defaultSIPPort = 5060
 
-// protectedPushReconnectGrace waits for P-CSCF to reopen port-s after it
-// RSTs the previous push TCP (normal after REGISTER refresh). Re-REGISTER
-// only if no replacement connection appears.
-var protectedPushReconnectGrace = 5 * time.Second
-
 func registerTransportDeadline(ctx context.Context, timeout time.Duration) time.Time {
 	deadline := time.Now().Add(timeout)
 	if ctx == nil {
@@ -271,9 +266,11 @@ func (s *Service) serveProtectedSIPConnection(conn net.Conn) {
 	}
 }
 
-// handleProtectedServerPushClosed re-registers when the last P-CSCF inbound
-// TCP (port-s) flow is gone. Outbound REGISTER TCP can still look healthy, so
-// MT SMS/INVITE would otherwise stay undeliverable until the next refresh.
+// handleProtectedServerPushClosed keeps the protected registration alive when
+// the last P-CSCF-initiated portS connection ends. portS is a reverse,
+// on-demand flow: it can be reopened when the P-CSCF has downlink SIP traffic.
+// Re-registering here is harmful on networks that reject a refresh over the
+// still-open portC flow.
 func (s *Service) handleProtectedServerPushClosed() {
 	if s == nil || s.stopped() {
 		return
@@ -284,36 +281,6 @@ func (s *Service) handleProtectedServerPushClosed() {
 	if remaining > 0 {
 		return
 	}
-	grace := protectedPushReconnectGrace
-	if grace <= 0 {
-		s.triggerRegisterImmediate("protected server push closed")
-		return
-	}
-	s.networkDone.Add(1)
-	go s.confirmProtectedPushReRegister(grace)
-}
-
-func (s *Service) confirmProtectedPushReRegister(grace time.Duration) {
-	defer s.networkDone.Done()
-	timer := time.NewTimer(grace)
-	defer timer.Stop()
-	select {
-	case <-s.stop:
-		return
-	case <-timer.C:
-	}
-	if s.stopped() {
-		return
-	}
-	s.protectedConnMu.Lock()
-	remaining := len(s.protectedConns)
-	s.protectedConnMu.Unlock()
-	if remaining > 0 {
-		logging.Info("IMS protected server push replaced; skip re-REGISTER",
-			"device", s.DeviceID(), "connections", remaining)
-		return
-	}
-	s.triggerRegisterImmediate("protected server push closed")
 }
 
 func (s *Service) trackProtectedConnection(conn net.Conn) bool {

--- a/third_party/vowifi-go/internal/vowifi/imscore/register_transport_test.go
+++ b/third_party/vowifi-go/internal/vowifi/imscore/register_transport_test.go
@@ -669,11 +669,7 @@ func sipHeaderValue(message, name string) string {
 	return ""
 }
 
-func TestProtectedServerPushClosureSchedulesReRegister(t *testing.T) {
-	previous := protectedPushReconnectGrace
-	protectedPushReconnectGrace = 5 * time.Millisecond
-	t.Cleanup(func() { protectedPushReconnectGrace = previous })
-
+func TestProtectedServerPushClosureKeepsRegistration(t *testing.T) {
 	service := newProtectedKeepaliveTestService(t)
 	service.mu.Lock()
 	service.registrationRefreshAt = time.Now().Add(time.Hour)
@@ -689,12 +685,11 @@ func TestProtectedServerPushClosureSchedulesReRegister(t *testing.T) {
 	}
 	service.untrackProtectedConnection(client)
 	service.handleProtectedServerPushClosed()
-	waitReRegisterPending(t, service)
 	if service.RegState() != regRegistered {
 		t.Fatalf("outbound registration dropped: %s", service.RegState())
 	}
-	if action := service.nextIMSMaintenanceAction(time.Now()); action != imsMaintenanceRefresh {
-		t.Fatalf("maintenance action = %d, want refresh", action)
+	if service.reRegisterPending.Load() {
+		t.Fatal("closed port-s flow scheduled re-REGISTER")
 	}
 }
 
@@ -722,11 +717,7 @@ func TestProtectedServerPushClosureKeepsOtherInboundFlows(t *testing.T) {
 	}
 }
 
-func TestServeProtectedSIPConnectionReRegistersOnReset(t *testing.T) {
-	previous := protectedPushReconnectGrace
-	protectedPushReconnectGrace = 5 * time.Millisecond
-	t.Cleanup(func() { protectedPushReconnectGrace = previous })
-
+func TestServeProtectedSIPConnectionKeepsRegistrationOnReset(t *testing.T) {
 	service := newProtectedKeepaliveTestService(t)
 	service.mu.Lock()
 	service.registrationRefreshAt = time.Now().Add(time.Hour)
@@ -751,17 +742,15 @@ func TestServeProtectedSIPConnectionReRegistersOnReset(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("serveProtectedSIPConnection did not return after reset")
 	}
-	waitReRegisterPending(t, service)
 	if service.RegState() != regRegistered {
 		t.Fatalf("outbound registration dropped: %s", service.RegState())
+	}
+	if service.reRegisterPending.Load() {
+		t.Fatal("closed port-s flow scheduled re-REGISTER")
 	}
 }
 
 func TestProtectedServerPushClosureSkipsReRegisterWhenReplaced(t *testing.T) {
-	previous := protectedPushReconnectGrace
-	protectedPushReconnectGrace = 30 * time.Millisecond
-	t.Cleanup(func() { protectedPushReconnectGrace = previous })
-
 	service := newProtectedKeepaliveTestService(t)
 	service.mu.Lock()
 	service.registrationRefreshAt = time.Now().Add(time.Hour)
@@ -783,20 +772,7 @@ func TestProtectedServerPushClosureSkipsReRegisterWhenReplaced(t *testing.T) {
 	if !service.trackProtectedConnection(alive) {
 		t.Fatal("replacement trackProtectedConnection")
 	}
-	time.Sleep(60 * time.Millisecond)
 	if service.reRegisterPending.Load() {
 		t.Fatal("replaced port-s still scheduled re-REGISTER")
 	}
-}
-
-func waitReRegisterPending(t *testing.T, service *Service) {
-	t.Helper()
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		if service.reRegisterPending.Load() {
-			return
-		}
-		time.Sleep(time.Millisecond)
-	}
-	t.Fatal("did not schedule re-REGISTER")
 }


### PR DESCRIPTION
## 补充修复

部分 P-CSCF 会按需关闭反向 portS TCP 连接；这不代表现有 IMS 注册或 portC 已失效。

此前 HiDeck 会在 portS EOF 后立即通过仍存活的旧 portC 重新 REGISTER。2degrees NZ 会对此返回 `503`，造成 IMS/SMS 短暂掉线。

现在保留已建立的注册和监听器，等待 P-CSCF 在有下行 SIP 流量时重新建立 portS。

## 验证

已在 2degrees NZ 实测：portS EOF 后不再触发 `503` 重注册，之后测试短信正常收到。

未使用其他运营商 SIM 卡测试。