### PR TITLE
fix(vowifi): allow MO SMS without port-s receiver

### DIFF
--- a/internal/api/automatic_tasks_executor.go
+++ b/internal/api/automatic_tasks_executor.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/iniwex5/vowifi-go/runtimehost"
 	"github.com/iniwex5/vowifi-go/runtimehost/voicehost"
 	"github.com/yibaiba/hideck/internal/automation"
 	"github.com/yibaiba/hideck/internal/db"
@@ -303,7 +304,7 @@ func waitForVoWiFiReady(ctx context.Context, pool *device.Pool, deviceID string,
 	defer ticker.Stop()
 	for {
 		state, ok := pool.GetVoWiFiRuntimeState(deviceID)
-		if ok && state.IMSReady && (!requireSMS || state.SMSReady) {
+		if ok && voWiFiReadyForTask(state, requireSMS) {
 			return nil
 		}
 		if ok && state.LastError != "" && (state.IMSState == "failed" || state.SessionState == "error") {
@@ -315,6 +316,10 @@ func waitForVoWiFiReady(ctx context.Context, pool *device.Pool, deviceID string,
 		case <-ticker.C:
 		}
 	}
+}
+
+func voWiFiReadyForTask(state runtimehost.State, requireSMS bool) bool {
+	return state.IMSReady && (!requireSMS || state.SMSMOReady || state.SMSReady)
 }
 
 func reportAutomationProgress(progress func(string) error, value string) error {

--- a/internal/api/automatic_tasks_sms_test.go
+++ b/internal/api/automatic_tasks_sms_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/iniwex5/vowifi-go/runtimehost"
 	"github.com/iniwex5/vowifi-go/runtimehost/messaging"
 	"github.com/yibaiba/hideck/internal/automation"
 	"github.com/yibaiba/hideck/internal/config"
@@ -66,5 +67,18 @@ func TestExecuteSMSDoesNotFallbackAfterIMSAccept(t *testing.T) {
 	}
 	if csCalls != 0 {
 		t.Fatalf("cs calls=%d", csCalls)
+	}
+}
+
+func TestVoWiFiReadyForSMSTaskUsesMOReadiness(t *testing.T) {
+	state := runtimehost.State{
+		IMSReady: true, SMSMOReady: true,
+		SMSReadyReason: "IMS SMS receiver is not ready",
+	}
+	if !voWiFiReadyForTask(state, true) {
+		t.Fatalf("MO-ready runtime blocked SMS task: %+v", state)
+	}
+	if voWiFiReadyForTask(runtimehost.State{IMSReady: true}, true) {
+		t.Fatal("SMS task started without MO readiness")
 	}
 }

--- a/internal/api/device_mgmt.go
+++ b/internal/api/device_mgmt.go
@@ -471,6 +471,7 @@ type voWiFiRuntimeDTO struct {
 	TunnelReady        bool      `json:"tunnel_ready"`
 	IMSReady           bool      `json:"ims_ready"`
 	SMSReady           bool      `json:"sms_ready"`
+	SMSMOReady         bool      `json:"sms_mo_ready"`
 	SMSReadyReason     string    `json:"sms_ready_reason,omitempty"`
 	RegStatus          int       `json:"reg_status"`
 	RegStatusText      string    `json:"reg_status_text"`
@@ -499,6 +500,7 @@ func runtimeStateToDTO(st runtimehost.State, status modem.DeviceStatus) *voWiFiR
 		TunnelReady:    st.TunnelReady,
 		IMSReady:       st.IMSReady,
 		SMSReady:       st.SMSReady,
+		SMSMOReady:     st.SMSMOReady,
 		SMSReadyReason: st.SMSReadyReason,
 		RegStatus:      st.RegStatus,
 		RegStatusText:  st.RegStatusText,
@@ -722,6 +724,7 @@ type overviewStreamEmitVersion struct {
 	TunnelReady           bool
 	IMSReady              bool
 	SMSReady              bool
+	SMSMOReady            bool
 	LastErrorClass        string
 	LebaraIdentityStatus  string
 	LebaraIdentityMessage string
@@ -746,6 +749,7 @@ func newOverviewStreamEmitVersion(item deviceMgmtOverviewLiteItem) overviewStrea
 		v.TunnelReady = item.VoWiFiRuntime.TunnelReady
 		v.IMSReady = item.VoWiFiRuntime.IMSReady
 		v.SMSReady = item.VoWiFiRuntime.SMSReady
+		v.SMSMOReady = item.VoWiFiRuntime.SMSMOReady
 		v.LastErrorClass = item.VoWiFiRuntime.LastErrorClass
 	}
 	return v
@@ -2999,6 +3003,7 @@ func (s *Server) handleDeviceMgmtOverviewStreamSingle(c *gin.Context) {
 				"tunnel_ready", readiness.TunnelReady,
 				"ims_ready", readiness.IMSReady,
 				"sms_ready", readiness.SMSReady,
+				"sms_mo_ready", readiness.SMSMOReady,
 				"last_reason", readiness.LastReason,
 				"last_error", readiness.LastError,
 				"last_error_class", readiness.LastErrorClass,

--- a/internal/api/device_mgmt_lifecycle_test.go
+++ b/internal/api/device_mgmt_lifecycle_test.go
@@ -64,11 +64,12 @@ func TestApplyLifecycleToListItemDerivesRadioRegistered(t *testing.T) {
 	}
 }
 
-func TestVoWiFiRuntimeDTOExportsSIMReadyOnly(t *testing.T) {
+func TestVoWiFiRuntimeDTOExportsReadinessFields(t *testing.T) {
 	dto := runtimeStateToDTO(runtimehost.State{
 		Phase:      runtimehost.PhaseSIMReady,
 		DeviceID:   "dev1",
 		SIMReady:   true,
+		SMSMOReady: true,
 		LastReason: "sim_ready",
 	}, modem.DeviceStatus{IMSI: "001010123456789"})
 
@@ -82,6 +83,9 @@ func TestVoWiFiRuntimeDTOExportsSIMReadyOnly(t *testing.T) {
 	raw := string(body)
 	if !strings.Contains(raw, `"sim_ready":true`) {
 		t.Fatalf("json=%s, want sim_ready=true", raw)
+	}
+	if !strings.Contains(raw, `"sms_mo_ready":true`) {
+		t.Fatalf("json=%s, want sms_mo_ready=true", raw)
 	}
 	if strings.Contains(raw, "radio_ready") {
 		t.Fatalf("json=%s should not contain radio_ready", raw)

--- a/internal/api/device_mgmt_overview_stream_test.go
+++ b/internal/api/device_mgmt_overview_stream_test.go
@@ -80,6 +80,10 @@ func TestOverviewStreamEmitVersionTracksRuntimeBusinessState(t *testing.T) {
 			item: deviceMgmtOverviewLiteItem{VoWiFiActive: true, VoWiFiRuntime: &voWiFiRuntimeDTO{Phase: "registering", TunnelReady: true, SMSReady: true}},
 		},
 		{
+			name: "sms mo changed",
+			item: deviceMgmtOverviewLiteItem{VoWiFiActive: true, VoWiFiRuntime: &voWiFiRuntimeDTO{Phase: "registering", TunnelReady: true, SMSMOReady: true}},
+		},
+		{
 			name: "last error class changed",
 			item: deviceMgmtOverviewLiteItem{VoWiFiActive: true, VoWiFiRuntime: &voWiFiRuntimeDTO{Phase: "registering", TunnelReady: true, LastErrorClass: "ims_register_failed"}},
 		},

--- a/internal/device/vowifi_sms_send.go
+++ b/internal/device/vowifi_sms_send.go
@@ -147,7 +147,7 @@ func sendVoWiFiSMSWhenReady(
 		if runtime != nil {
 			state := runtime.State()
 			lastReason = voWiFiSMSWaitReason(state)
-			if state.SMSReady || !shouldWaitForVoWiFiSMS(state) {
+			if state.SMSMOReady || state.SMSReady || !shouldWaitForVoWiFiSMS(state) {
 				outcome, err := runtime.SendSMSWithOptions(ctx, request.To, request.Text, request.Options)
 				if err == nil || !errors.Is(err, messaging.ErrSMSNotReady) {
 					return outcome, err
@@ -175,7 +175,7 @@ func currentVoWiFiSMSRuntime(getter func() voWiFiSMSRuntime) voWiFiSMSRuntime {
 }
 
 func shouldWaitForVoWiFiSMS(state runtimehost.State) bool {
-	return !state.SMSReady && !strings.EqualFold(
+	return !state.SMSMOReady && !state.SMSReady && !strings.EqualFold(
 		strings.TrimSpace(state.SMSReadyReason), "IMS SMSC is not configured",
 	)
 }

--- a/internal/device/vowifi_sms_send_test.go
+++ b/internal/device/vowifi_sms_send_test.go
@@ -28,6 +28,24 @@ func TestSendVoWiFiSMSWhenReadySendsImmediately(t *testing.T) {
 	}
 }
 
+func TestSendVoWiFiSMSWhenMOReadyDoesNotWaitForMTReceiver(t *testing.T) {
+	runtime := &fakeVoWiFiSMSRuntime{state: runtimehost.State{
+		IMSReady: true, SMSMOReady: true, SMSReadyReason: "IMS SMS receiver is not ready",
+	}}
+	runtime.send = func(context.Context, string, string, messaging.SendOptions) (messaging.SendOutcome, error) {
+		return messaging.SendOutcome{MessageID: "msg-mo-ready"}, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	outcome, err := sendVoWiFiSMSWhenReady(ctx, voWiFiSMSSendRequest{
+		DeviceID: "wwan0", To: "+15551234567", Text: "test", Updates: make(chan runtimehost.State),
+		Runtime: func() voWiFiSMSRuntime { return runtime },
+	})
+	if err != nil || outcome.MessageID != "msg-mo-ready" || runtime.sendCount() != 1 {
+		t.Fatalf("MO-ready send outcome=%+v err=%v count=%d", outcome, err, runtime.sendCount())
+	}
+}
+
 func TestSendVoWiFiSMSWhenReadyWaitsAcrossRecovery(t *testing.T) {
 	failedRuntime := &fakeVoWiFiSMSRuntime{state: runtimehost.State{
 		SMSReadyReason: "IMS registration is not ready",

--- a/third_party/vowifi-go/internal/vowifi/imscore/sms_outbound.go
+++ b/third_party/vowifi-go/internal/vowifi/imscore/sms_outbound.go
@@ -84,7 +84,7 @@ func (s *Service) prepareSendEnv(
 		return nil, errors.New("imscore: service not configured")
 	}
 	readiness := s.SMSReadiness()
-	if !readiness.Ready {
+	if !readiness.MOReady {
 		return nil, fmt.Errorf("imscore: %w: %s", smsdelivery.ErrSMSNotReady, readiness.Reason)
 	}
 	destination, err := parseSMSDestination(to)

--- a/third_party/vowifi-go/internal/vowifi/imscore/sms_readiness.go
+++ b/third_party/vowifi-go/internal/vowifi/imscore/sms_readiness.go
@@ -126,6 +126,8 @@ func evaluateSMSReadiness(registered, profileReady, transportReady, receiverRead
 		ReceiverReady:  receiverReady,
 		SMSCPresent:    strings.TrimSpace(smsc) != "",
 	}
+	readiness.MOReady = readiness.Registered && readiness.ProfileReady &&
+		readiness.TransportReady && readiness.SMSCPresent
 	switch {
 	case !readiness.Registered:
 		readiness.Reason = smsReadyReasonNotRegistered
@@ -133,6 +135,8 @@ func evaluateSMSReadiness(registered, profileReady, transportReady, receiverRead
 		readiness.Reason = smsReadyReasonProfileNotReady
 	case !readiness.TransportReady:
 		readiness.Reason = smsReadyReasonTransportNotReady
+	case !readiness.SMSCPresent && !readiness.ReceiverReady:
+		readiness.Reason = smsReadyReasonSMSCNotConfigured
 	case !readiness.ReceiverReady:
 		readiness.Reason = smsReadyReasonReceiverNotReady
 	default:

--- a/third_party/vowifi-go/internal/vowifi/imscore/sms_readiness_test.go
+++ b/third_party/vowifi-go/internal/vowifi/imscore/sms_readiness_test.go
@@ -44,6 +44,31 @@ func TestProtectedSMSReadinessRequiresPortSFlow(t *testing.T) {
 	}
 }
 
+func TestProtectedSMSReadinessAllowsMOSendWithoutPortSFlow(t *testing.T) {
+	service := newProtectedKeepaliveTestService(t)
+	registration, registrationPeer := net.Pipe()
+	t.Cleanup(func() { _ = registrationPeer.Close() })
+	service.mu.Lock()
+	service.registrationTCP = registration
+	service.registrationTCPProtected = true
+	service.mu.Unlock()
+
+	got := service.SMSReadiness()
+	if got.Ready || got.ReceiverReady || !got.MOReady {
+		t.Fatalf("readiness without port-s = %+v, want MT unready and MO ready", got)
+	}
+	if _, err := service.prepareSendEnv(nil, "+15551234567", "test", SendOptions{}); err != nil {
+		t.Fatalf("prepareSendEnv without port-s: %v", err)
+	}
+}
+
+func TestSMSReadinessReportsMissingSMSCBeforeReceiver(t *testing.T) {
+	got := evaluateSMSReadiness(true, true, true, false, "")
+	if got.MOReady || got.Reason != smsReadyReasonSMSCNotConfigured {
+		t.Fatalf("readiness without receiver or SMSC = %+v, want missing SMSC", got)
+	}
+}
+
 func TestProtectedSMSHealthTreatsOnlyCleanEOFAsOnDemand(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/third_party/vowifi-go/runtimehost/adapters.go
+++ b/third_party/vowifi-go/runtimehost/adapters.go
@@ -87,7 +87,7 @@ func adaptSMSReadiness(readiness imscore.SMSReadiness) SMSReadiness {
 		Registered: readiness.Registered, ProfileReady: readiness.ProfileReady,
 		TransportReady: readiness.TransportReady, ReceiverReady: readiness.ReceiverReady,
 		SMSCPresent: readiness.SMSCPresent, Ready: readiness.Ready,
-		HealthReady: readiness.HealthReady, Reason: readiness.Reason,
+		MOReady: readiness.MOReady, HealthReady: readiness.HealthReady, Reason: readiness.Reason,
 	}
 }
 
@@ -260,7 +260,7 @@ func (a serviceAdapter) StatusCurrent() Status {
 	}
 	return Status{State: State{
 		Phase: "ready", DeviceID: status.DeviceID,
-		IMSReady: status.IsRegistered(), SMSReady: sms.Ready, SMSHealthReady: sms.HealthReady,
+		IMSReady: status.IsRegistered(), SMSReady: sms.Ready, SMSMOReady: sms.MOReady, SMSHealthReady: sms.HealthReady,
 		RegStatus: boolStatus(status.IsRegistered()), RegStatusText: status.RegStatus,
 		SessionState: "established", IMSState: status.RegState, SMSReadyReason: sms.Reason,
 	}}

--- a/third_party/vowifi-go/runtimehost/adapters_test.go
+++ b/third_party/vowifi-go/runtimehost/adapters_test.go
@@ -120,6 +120,9 @@ func TestServiceAdapterStatus(t *testing.T) {
 	if !st.State.SMSReady {
 		t.Errorf("SMSReady should be true: %s", st.State.SMSReadyReason)
 	}
+	if !st.State.SMSMOReady {
+		t.Errorf("SMSMOReady should be true: %s", st.State.SMSReadyReason)
+	}
 	if st.State.DeviceID != "dev-1" {
 		t.Errorf("device = %q", st.State.DeviceID)
 	}
@@ -166,6 +169,24 @@ func TestAdaptSMSSendOutcomePreservesIdentity(t *testing.T) {
 	}
 	if out.DeliveryState != "failed" || out.Err != nil || out.SIPCode != 503 || !out.RecommendCSFallback {
 		t.Fatalf("delivery failure = %+v", out)
+	}
+}
+
+func TestAdaptSMSReadinessPreservesMOSendWithoutMTReceiver(t *testing.T) {
+	readiness := adaptSMSReadiness(imscore.SMSReadiness{
+		Registered: true, ProfileReady: true, TransportReady: true,
+		SMSCPresent: true, MOReady: true, Reason: "IMS SMS receiver is not ready",
+	})
+	instance := &Instance{}
+	instance.setState(State{IMSReady: true})
+	instance.updateSMSReadiness(readiness)
+
+	state := instance.State()
+	if !state.SMSMOReady {
+		t.Fatalf("MO SMS readiness was lost across runtime adapters: %+v", state)
+	}
+	if state.SMSReady {
+		t.Fatalf("MT SMS readiness was incorrectly enabled: %+v", state)
 	}
 }
 

--- a/third_party/vowifi-go/runtimehost/current_lifecycle.go
+++ b/third_party/vowifi-go/runtimehost/current_lifecycle.go
@@ -62,7 +62,7 @@ func (adapter lifecycleServiceAdapter) Status() map[string]interface{} {
 	state := adapter.lifecycle.Status().State
 	return map[string]interface{}{
 		"device_id": state.DeviceID, "phase": state.Phase,
-		"ims_ready": state.IMSReady, "sms_ready": state.SMSReady,
+		"ims_ready": state.IMSReady, "sms_ready": state.SMSReady, "sms_mo_ready": state.SMSMOReady,
 	}
 }
 

--- a/third_party/vowifi-go/runtimehost/instance.go
+++ b/third_party/vowifi-go/runtimehost/instance.go
@@ -107,6 +107,7 @@ func (i *Instance) Stop(ctx context.Context) error {
 		state.TunnelReady = false
 		state.IMSReady = false
 		state.SMSReady = false
+		state.SMSMOReady = false
 		state.SMSHealthReady = false
 		state.LastReason = "stopped"
 	})
@@ -148,6 +149,7 @@ func (i *Instance) Obs() map[string]interface{} {
 		"tunnel_ready":     st.TunnelReady,
 		"ims_ready":        st.IMSReady,
 		"sms_ready":        st.SMSReady,
+		"sms_mo_ready":     st.SMSMOReady,
 		"sms_health_ready": st.SMSHealthReady,
 		"session_state":    st.SessionState,
 		"ims_state":        st.IMSState,
@@ -205,6 +207,7 @@ func (i *Instance) updateTunnelState(sessionState string) {
 			state.IMSState = "failed"
 			state.IMSReady = false
 			state.SMSReady = false
+			state.SMSMOReady = false
 			state.SMSHealthReady = false
 			state.RegStatus = 0
 			state.RegStatusText = "failed"
@@ -232,6 +235,7 @@ func (i *Instance) markIMSRegistered() {
 		state.IMSState = "registered"
 		state.IMSReady = true
 		state.SMSReady = false
+		state.SMSMOReady = false
 		state.SMSReadyReason = "IMS SMS readiness has not been reported"
 		state.RegStatus = 1
 		state.RegStatusText = "registered"
@@ -242,6 +246,7 @@ func (i *Instance) markIMSRegistered() {
 func (i *Instance) updateSMSReadiness(readiness SMSReadiness) {
 	i.updateState(func(state *State) {
 		state.SMSReady = state.IMSReady && readiness.Ready
+		state.SMSMOReady = state.IMSReady && readiness.MOReady
 		state.SMSHealthReady = readiness.Registered && (readiness.Ready || readiness.HealthReady)
 		state.SMSReadyReason = readiness.Reason
 		if state.SMSReady {
@@ -285,6 +290,7 @@ func (i *Instance) setIMSFailure(err error) {
 		state.DataPlaneUp = false
 		state.IMSReady = false
 		state.SMSReady = false
+		state.SMSMOReady = false
 		state.SMSHealthReady = false
 		state.RegStatus = 0
 		state.RegStatusText = "failed"
@@ -303,6 +309,7 @@ func (i *Instance) setIMSRefreshFailure(err error) {
 		state.LastReason = "IMS registration refresh failed"
 		state.IMSReady = false
 		state.SMSReady = false
+		state.SMSMOReady = false
 		state.SMSHealthReady = false
 		state.RegStatus = 0
 		state.RegStatusText = "failed"
@@ -323,6 +330,7 @@ func (i *Instance) setTunnelControlFailure(err error) {
 		state.DataPlaneUp = false
 		state.IMSReady = false
 		state.SMSReady = false
+		state.SMSMOReady = false
 		state.SMSHealthReady = false
 		state.RegStatus = 0
 		state.RegStatusText = "failed"
@@ -343,6 +351,7 @@ func (i *Instance) setTunnelReauthenticationRequired(err error) {
 		state.DataPlaneUp = false
 		state.IMSReady = false
 		state.SMSReady = false
+		state.SMSMOReady = false
 		state.SMSHealthReady = false
 		state.RegStatus = 0
 		state.RegStatusText = "restarting"

--- a/third_party/vowifi-go/runtimehost/instance.go
+++ b/third_party/vowifi-go/runtimehost/instance.go
@@ -245,21 +245,25 @@ func (i *Instance) markIMSRegistered() {
 
 func (i *Instance) updateSMSReadiness(readiness SMSReadiness) {
 	i.updateState(func(state *State) {
-		state.SMSReady = state.IMSReady && readiness.Ready
-		state.SMSMOReady = state.IMSReady && readiness.MOReady
-		state.SMSHealthReady = readiness.Registered && (readiness.Ready || readiness.HealthReady)
-		state.SMSReadyReason = readiness.Reason
-		if state.SMSReady {
-			state.Phase = "sms_ready"
-			state.LastEvent = "sms_ready"
-			clearRecoveredFailure(state)
-			return
-		}
-		if state.IMSReady {
-			state.Phase = "ims_ready"
-			state.LastEvent = "sms_unavailable"
-		}
+		applySMSReadiness(state, readiness)
 	})
+}
+
+func applySMSReadiness(state *State, readiness SMSReadiness) {
+	state.SMSReady = state.IMSReady && readiness.Ready
+	state.SMSMOReady = state.IMSReady && readiness.MOReady
+	state.SMSHealthReady = readiness.Registered && (readiness.Ready || readiness.HealthReady)
+	state.SMSReadyReason = readiness.Reason
+	if state.SMSReady {
+		state.Phase = "sms_ready"
+		state.LastEvent = "sms_ready"
+		clearRecoveredFailure(state)
+		return
+	}
+	if state.IMSReady {
+		state.Phase = "ims_ready"
+		state.LastEvent = "sms_unavailable"
+	}
 }
 
 func (i *Instance) setStartFailure(err error) {

--- a/third_party/vowifi-go/runtimehost/runtime_restoration_test.go
+++ b/third_party/vowifi-go/runtimehost/runtime_restoration_test.go
@@ -64,6 +64,33 @@ func TestCoreSMSReadinessUpdatesRuntimeState(t *testing.T) {
 	}
 }
 
+func TestCoreReplaysMOSMSReadinessAfterIMSRegistration(t *testing.T) {
+	instance := &Instance{}
+	instance.setState(State{DeviceID: "wwan0", Phase: "ipsec_up"})
+	observer := &instanceObserver{inst: instance, deviceID: "wwan0"}
+	request := runtimecore.RuntimeStartRequest{}
+	chainSMSReadinessHook(&request, observer)
+
+	request.Hooks.OnSMSReadinessChanged(context.Background(), imscore.SMSReadiness{
+		Registered: true, ProfileReady: true, TransportReady: true,
+		SMSCPresent: true, MOReady: true, Reason: "IMS SMS receiver is not ready",
+	})
+	if state := instance.State(); state.SMSMOReady {
+		t.Fatalf("MO readiness published before IMS registration: %+v", state)
+	}
+
+	observer.OnRuntimeEvent(context.Background(), runtimecore.RuntimeEvent[*runtimecore.SessionResult]{
+		Kind: "ims_registered", DeviceID: "wwan0",
+	})
+	state := instance.State()
+	if !state.IMSReady || !state.SMSMOReady {
+		t.Fatalf("MO readiness lost after IMS registration: %+v", state)
+	}
+	if state.SMSReady || state.SMSReadyReason != "IMS SMS receiver is not ready" {
+		t.Fatalf("MT readiness changed after IMS registration: %+v", state)
+	}
+}
+
 func TestCoreSMSHealthReadinessIsRecordedBeforeSessionPublication(t *testing.T) {
 	instance := &Instance{}
 	instance.setState(State{DeviceID: "wwan0", Phase: "ipsec_up"})

--- a/third_party/vowifi-go/runtimehost/runtimecore_observer.go
+++ b/third_party/vowifi-go/runtimehost/runtimecore_observer.go
@@ -10,10 +10,13 @@ import (
 )
 
 type instanceObserver struct {
-	inst      *Instance
-	deviceID  string
-	ready     chan struct{}
-	readyOnce sync.Once
+	inst               *Instance
+	deviceID           string
+	ready              chan struct{}
+	readyOnce          sync.Once
+	smsReadinessMu     sync.Mutex
+	latestSMSReadiness SMSReadiness
+	hasSMSReadiness    bool
 }
 
 func (observer *instanceObserver) OnRuntimeEvent(
@@ -36,6 +39,9 @@ func (observer *instanceObserver) OnRuntimeEvent(
 	}
 	observer.applyEvent(kind, event, &state)
 	state.LastEvent = kind
+	if kind == "ims_registered" {
+		observer.applyLatestSMSReadiness(&state)
+	}
 	state.UpdatedAt = time.Now()
 	observer.inst.setState(state)
 	observer.inst.publish(ctx, Event{
@@ -44,6 +50,24 @@ func (observer *instanceObserver) OnRuntimeEvent(
 		RedirectEPDG: event.RedirectEPDG, State: state,
 		Type: kind, Detail: event.Reason, Session: observer.inst,
 	})
+}
+
+func (observer *instanceObserver) updateSMSReadiness(readiness SMSReadiness) {
+	observer.smsReadinessMu.Lock()
+	observer.latestSMSReadiness = readiness
+	observer.hasSMSReadiness = true
+	observer.smsReadinessMu.Unlock()
+	observer.inst.updateSMSReadiness(readiness)
+}
+
+func (observer *instanceObserver) applyLatestSMSReadiness(state *State) {
+	observer.smsReadinessMu.Lock()
+	readiness := observer.latestSMSReadiness
+	ok := observer.hasSMSReadiness
+	observer.smsReadinessMu.Unlock()
+	if ok {
+		applySMSReadiness(state, readiness)
+	}
 }
 
 func (observer *instanceObserver) applyEvent(

--- a/third_party/vowifi-go/runtimehost/runtimecore_observer.go
+++ b/third_party/vowifi-go/runtimehost/runtimecore_observer.go
@@ -82,6 +82,7 @@ func (observer *instanceObserver) applyEvent(
 	case "sms_ready":
 		state.Phase = "sms_ready"
 		state.SMSReady = true
+		state.SMSMOReady = true
 		state.SMSHealthReady = true
 		clearRecoveredFailure(state)
 	case "interrupted":
@@ -136,6 +137,7 @@ func markIMSUnavailable(state *State, status string) {
 	state.IMSState = status
 	state.IMSReady = false
 	state.SMSReady = false
+	state.SMSMOReady = false
 	state.SMSHealthReady = false
 	state.SMSReadyReason = ""
 	state.RegStatus = 0

--- a/third_party/vowifi-go/runtimehost/runtimecore_start.go
+++ b/third_party/vowifi-go/runtimehost/runtimecore_start.go
@@ -138,7 +138,7 @@ func chainSMSReadinessHook(
 		if previous != nil {
 			previous(ctx, readiness)
 		}
-		observer.inst.updateSMSReadiness(adaptSMSReadiness(readiness))
+		observer.updateSMSReadiness(adaptSMSReadiness(readiness))
 	}
 }
 

--- a/third_party/vowifi-go/runtimehost/types.go
+++ b/third_party/vowifi-go/runtimehost/types.go
@@ -46,6 +46,7 @@ type State struct {
 	EPDGAddress    string
 	SMSReadyReason string
 	SMSHealthReady bool
+	SMSMOReady     bool
 }
 
 // Event retains the recovered runtime event payload before additive fields.
@@ -154,6 +155,7 @@ type SMSReadiness struct {
 	ReceiverReady  bool
 	SMSCPresent    bool
 	Ready          bool
+	MOReady        bool
 	HealthReady    bool
 	Reason         string
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -65,6 +65,7 @@ export type VoWiFiRuntimeState = {
   tunnel_ready?: boolean
   ims_ready?: boolean
   sms_ready?: boolean
+  sms_mo_ready?: boolean
   sms_ready_reason?: string
   reg_status?: number
   reg_status_text?: string

--- a/web/src/utils/smsPresentation.ts
+++ b/web/src/utils/smsPresentation.ts
@@ -99,9 +99,12 @@ function resolveConversationDevice(options: Readonly<{
 
 function readinessContext(device: DeviceMgmtListItem | undefined) {
   const runtime = device?.vowifi_runtime
+  const smsSendReady = runtime?.sms_mo_ready ?? runtime?.sms_ready
   return {
-    smsLabel: readinessLabel(runtime?.sms_ready, 'SMS', runtime?.sms_ready_reason),
-    smsTone: readinessTone(runtime?.sms_ready),
+    smsLabel: runtime?.sms_mo_ready === true
+      ? 'VoWiFi · SMS 可发送'
+      : readinessLabel(smsSendReady, 'SMS', runtime?.sms_ready_reason),
+    smsTone: readinessTone(smsSendReady),
     imsLabel: readinessLabel(runtime?.ims_ready, 'IMS'),
     imsTone: readinessTone(runtime?.ims_ready)
   } as const

--- a/web/tests/smsPresentation.test.ts
+++ b/web/tests/smsPresentation.test.ts
@@ -61,6 +61,23 @@ test('conversation context exposes only backend readiness facts', () => {
   assert.equal(unknown.imsLabel, 'IMS 状态未提供')
 })
 
+test('conversation context reports outbound SMS ready when only the IMS receiver is unavailable', () => {
+  const runtime = {
+    ims_ready: true,
+    sms_ready: false,
+    sms_mo_ready: true,
+    sms_ready_reason: 'IMS SMS receiver is not ready'
+  }
+  const context = createSmsConversationContext({
+    selectedDeviceId: 'wwan0',
+    thread: null,
+    devices: [device({ vowifi_runtime: runtime })]
+  })
+
+  assert.equal(context.smsLabel, 'VoWiFi · SMS 可发送')
+  assert.equal(context.smsTone, 'success')
+})
+
 test('unread badges and initials are explicit and bounded', () => {
   assert.equal(smsUnreadBadge(3), 3)
   assert.equal(smsUnreadBadge(-2), 0)


### PR DESCRIPTION
Closes #12

## 问题

在 IMS 已注册、SMSC/profile/出站传输可用，但 port-s 下行 receiver 未建立的运营商环境中，MO SMS 会被统一的 `SMSReady` 门控阻塞，并提示 `IMS SMS receiver is not ready`。运营商返回的 SUBSCRIBE(reg) 403 / SUBSCRIBE(mwi) 405 是非致命事件订阅拒绝，不应阻止出站短信。

此外，SMS readiness 回调可能先于 `ims_registered` 到达。旧逻辑会在 IMS 尚未标记 ready 时丢失 MO-ready 状态，注册完成后也不会重放，从而持续阻塞发送。

## 修改

- 在 imscore/runtimehost 中拆分 MO 发送就绪与 MT receiver 就绪；
- 出站 SMS、手动发送等待和自动任务改用 MO readiness；
- 保留 `SMSReady` 表示 MT/完整接收能力，不改变 port-s 接收语义；
- 缓存最新 readiness，并在 `ims_registered` 后重放，修复回调乱序；
- API 增加可选的 `sms_mo_ready` 字段；
- Web 端优先使用 `sms_mo_ready` 展示发送能力，缺失时回退到 `sms_ready`，兼容旧后端；
- 增加 MO/MT 分离、缺失 SMSC、状态投影、自动任务和注册/readiness 乱序回归测试。

## 行为变化

- IMS 已注册且 MO 前置条件满足时，即使 port-s receiver 未就绪，也允许发出 SIP MESSAGE；
- MT receiver 状态仍保持未就绪，不会被误报；
- SUBSCRIBE 403/405 继续记录为非致命 warning，并保留当前 IMS 注册。

## 验证

- `go test ./internal/device ./internal/api ./internal/vowifihost -count=1`
- `go test ./runtimehost ./internal/vowifi/runtimecore -count=1`
- imscore MO readiness / SMSC 定向回归测试
- Web lint、typecheck、Node 20 production build
- `smsPresentation.test.ts`：5/5 通过
- `git diff --check`

说明：当前宿主机运行完整 imscore 套件时，既有的 `TestIPSec3GPPListenerAppliesTCPMSS` 因内核返回 `protocol not available` 失败；本次相关 imscore 定向测试均通过。
