### PR TITLE
fix(pcsc): use native LONG for context and card handles

### DIFF
--- a/internal/pcsc/backend_supported.go
+++ b/internal/pcsc/backend_supported.go
@@ -33,16 +33,16 @@ type systemBackend struct {
 
 type winscardAPI struct {
 	library          uintptr
-	establishContext func(pcscDword, uintptr, uintptr, *uintptr) pcscLong
-	releaseContext   func(uintptr) pcscLong
-	listReaders      func(uintptr, uintptr, []byte, *pcscDword) pcscLong
-	connect          func(uintptr, string, pcscDword, pcscDword, *uintptr, *pcscDword) pcscLong
-	disconnect       func(uintptr, pcscDword) pcscLong
-	beginTransaction func(uintptr) pcscLong
-	endTransaction   func(uintptr, pcscDword) pcscLong
-	status           func(uintptr, []byte, *pcscDword, *pcscDword, *pcscDword, []byte, *pcscDword) pcscLong
-	transmit         func(uintptr, *ioRequest, []byte, pcscDword, *ioRequest, []byte, *pcscDword) pcscLong
-	getAttrib        func(uintptr, pcscDword, []byte, *pcscDword) pcscLong
+	establishContext func(pcscDword, uintptr, uintptr, *pcscLong) pcscLong
+	releaseContext   func(pcscLong) pcscLong
+	listReaders      func(pcscLong, uintptr, []byte, *pcscDword) pcscLong
+	connect          func(pcscLong, string, pcscDword, pcscDword, *pcscLong, *pcscDword) pcscLong
+	disconnect       func(pcscLong, pcscDword) pcscLong
+	beginTransaction func(pcscLong) pcscLong
+	endTransaction   func(pcscLong, pcscDword) pcscLong
+	status           func(pcscLong, []byte, *pcscDword, *pcscDword, *pcscDword, []byte, *pcscDword) pcscLong
+	transmit         func(pcscLong, *ioRequest, []byte, pcscDword, *ioRequest, []byte, *pcscDword) pcscLong
+	getAttrib        func(pcscLong, pcscDword, []byte, *pcscDword) pcscLong
 }
 
 func newSystemBackend() Backend { return &systemBackend{} }
@@ -132,8 +132,8 @@ func checkPCSC(operation string, result pcscLong) error {
 	}
 }
 
-func (api *winscardAPI) context() (uintptr, error) {
-	var handle uintptr
+func (api *winscardAPI) context() (pcscLong, error) {
+	var handle pcscLong
 	if err := checkPCSC("SCardEstablishContext", api.establishContext(pcscScopeSystem, 0, 0, &handle)); err != nil {
 		return 0, err
 	}
@@ -173,7 +173,7 @@ func (backend *systemBackend) Readers(ctx context.Context) ([]Reader, error) {
 	return readers, contextError(ctx)
 }
 
-func (api *winscardAPI) readerNames(handle uintptr) ([]string, error) {
+func (api *winscardAPI) readerNames(handle pcscLong) ([]string, error) {
 	var size pcscDword
 	result := api.listReaders(handle, 0, nil, &size)
 	if uint32(result) == 0x8010002E {
@@ -216,8 +216,8 @@ func readerProduct(name string) string {
 	return strings.TrimSpace(trimmed)
 }
 
-func (api *winscardAPI) enrichReader(contextHandle uintptr, reader *Reader) {
-	var card uintptr
+func (api *winscardAPI) enrichReader(contextHandle pcscLong, reader *Reader) {
+	var card pcscLong
 	var protocol pcscDword
 	result := api.connect(contextHandle, reader.Name+"\x00", pcscShareShared, pcscProtocolAny, &card, &protocol)
 	if result == 0 {
@@ -233,7 +233,7 @@ func (api *winscardAPI) enrichReader(contextHandle uintptr, reader *Reader) {
 	}
 }
 
-func (api *winscardAPI) readCardDetails(card uintptr, reader *Reader) {
+func (api *winscardAPI) readCardDetails(card pcscLong, reader *Reader) {
 	nameBuffer := make([]byte, 256)
 	atrBuffer := make([]byte, 64)
 	nameLength, atrLength := pcscDword(len(nameBuffer)), pcscDword(len(atrBuffer))
@@ -245,7 +245,7 @@ func (api *winscardAPI) readCardDetails(card uintptr, reader *Reader) {
 	api.readUSBPath(card, reader)
 }
 
-func (api *winscardAPI) readUSBPath(card uintptr, reader *Reader) {
+func (api *winscardAPI) readUSBPath(card pcscLong, reader *Reader) {
 	attribute := make([]byte, 8)
 	length := pcscDword(len(attribute))
 	if api.getAttrib(card, pcscAttrChannelID, attribute, &length) != 0 || length < 4 {
@@ -281,7 +281,7 @@ func (backend *systemBackend) Open(ctx context.Context, selector Selector) (Card
 	if err != nil {
 		return nil, err
 	}
-	var cardHandle uintptr
+	var cardHandle pcscLong
 	var protocol pcscDword
 	result := api.connect(contextHandle, reader.Name+"\x00", pcscShareShared, pcscProtocolAny, &cardHandle, &protocol)
 	if err := checkPCSC("SCardConnect", result); err != nil {

--- a/internal/pcsc/card_supported.go
+++ b/internal/pcsc/card_supported.go
@@ -16,8 +16,8 @@ const (
 
 type systemCard struct {
 	api      *winscardAPI
-	context  uintptr
-	handle   uintptr
+	context  pcscLong
+	handle   pcscLong
 	protocol pcscDword
 	closed   bool
 	mu       sync.Mutex

--- a/internal/pcsc/native_abi_test.go
+++ b/internal/pcsc/native_abi_test.go
@@ -1,0 +1,100 @@
+//go:build darwin || linux
+
+package pcsc
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+	"unsafe"
+
+	"github.com/ebitengine/purego"
+)
+
+func TestNativePCSCLayout(test *testing.T) {
+	wordSize := unsafe.Sizeof(uintptr(0))
+	if runtime.GOOS == "darwin" {
+		wordSize = 4
+	}
+	api := winscardAPI{}
+	checks := map[string]uintptr{
+		"DWORD output":      reflect.TypeOf(api.status).In(2).Elem().Size(),
+		"LONG return":       reflect.TypeOf(api.status).Out(0).Size(),
+		"context output":    reflect.TypeOf(api.establishContext).In(3).Elem().Size(),
+		"card handle":       reflect.TypeOf(api.status).In(0).Size(),
+		"PCI protocol":      unsafe.Sizeof(ioRequest{}.Protocol),
+		"PCI length offset": unsafe.Offsetof(ioRequest{}.Length),
+	}
+	for name, actual := range checks {
+		if actual != wordSize {
+			test.Errorf("%s: got %d bytes, want %d", name, actual, wordSize)
+		}
+	}
+	if actual := unsafe.Sizeof(ioRequest{}); actual != 2*wordSize {
+		test.Errorf("PCI size: got %d bytes, want %d", actual, 2*wordSize)
+	}
+}
+
+func TestNativePCSCErrorCodes(test *testing.T) {
+	code := uint32(0x8010000C)
+	for _, result := range []pcscLong{pcscLong(int32(code)), pcscLong(code)} {
+		if err := checkPCSC("SCardConnect", result); !errors.Is(err, ErrNoCard) {
+			test.Fatalf("result %d: expected ErrNoCard, got %v", result, err)
+		}
+	}
+}
+
+func TestNativePCSCCalls(test *testing.T) {
+	compiler, err := exec.LookPath("cc")
+	if err != nil {
+		test.Skip("C compiler required for native ABI regression test")
+	}
+	libraryPath := filepath.Join(test.TempDir(), "pcsc-fixture.so")
+	flags := []string{"-shared", "-fPIC"}
+	if runtime.GOOS == "darwin" {
+		flags = []string{"-dynamiclib"}
+	}
+	flags = append(flags, "-Wall", "-Wextra", "-Werror", "-o", libraryPath, "testdata/native_pcsc.c")
+	if output, err := exec.Command(compiler, flags...).CombinedOutput(); err != nil {
+		test.Fatalf("compile native fixture: %v\n%s", err, output)
+	}
+	library, err := purego.Dlopen(libraryPath, purego.RTLD_NOW|purego.RTLD_LOCAL)
+	if err != nil {
+		test.Fatal(err)
+	}
+	test.Cleanup(func() { _ = purego.Dlclose(library) })
+	var nativePCISize func() uintptr
+	purego.RegisterLibFunc(&nativePCISize, library, "NativePCISize")
+	if actual := nativePCISize(); actual != unsafe.Sizeof(ioRequest{}) {
+		test.Fatalf("native PCI size %d differs from Go size %d", actual, unsafe.Sizeof(ioRequest{}))
+	}
+	api := &winscardAPI{library: library}
+	if err := api.bind(); err != nil {
+		test.Fatal(err)
+	}
+	backend := &systemBackend{api: api}
+	backend.once.Do(func() {})
+	readers, err := backend.Readers(context.Background())
+	if err != nil {
+		test.Fatal(err)
+	}
+	if len(readers) != 1 || readers[0].Name != "ABI Reader 00 00" || !readers[0].CardPresent || readers[0].ATR != "3B00" {
+		test.Fatalf("unexpected readers: %+v", readers)
+	}
+	card, err := backend.Open(context.Background(), Selector{ReaderName: readers[0].Name})
+	if err != nil {
+		test.Fatal(err)
+	}
+	defer card.Close()
+	response, status, err := card.Transmit(context.Background(), []byte{0x00, 0xA4, 0x00, 0x00})
+	if err != nil || len(response) != 0 || status != 0x9000 {
+		test.Fatalf("transmit: response=%X status=%04X err=%v", response, status, err)
+	}
+	if err := card.Close(); err != nil {
+		test.Fatal(err)
+	}
+}

--- a/internal/pcsc/testdata/native_pcsc.c
+++ b/internal/pcsc/testdata/native_pcsc.c
@@ -1,0 +1,96 @@
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#ifdef __APPLE__
+typedef uint32_t DWORD;
+typedef int32_t LONG;
+#else
+typedef unsigned long DWORD;
+typedef long LONG;
+#endif
+
+typedef struct {
+    DWORD protocol;
+    DWORD length;
+} PCI;
+
+static const char reader_name[] = "ABI Reader 00 00";
+static const LONG context_handle = 0x12345678;
+static const LONG card_handle = 0x23456789;
+
+size_t NativePCISize(void) { return sizeof(PCI); }
+
+LONG SCardEstablishContext(DWORD scope, const void *reserved_first,
+                          const void *reserved_second, LONG *context) {
+    if (scope != 2 || reserved_first || reserved_second) return -1;
+    *context = context_handle;
+    return 0;
+}
+
+LONG SCardReleaseContext(LONG context) {
+    return context == context_handle ? 0 : -1;
+}
+
+LONG SCardListReaders(LONG context, const char *groups, char *readers, DWORD *length) {
+    if (context != context_handle || groups) return -1;
+    DWORD required = sizeof(reader_name) + 1;
+    if (readers) {
+        if (*length != required) return -1;
+        memcpy(readers, reader_name, sizeof(reader_name));
+        readers[sizeof(reader_name)] = '\0';
+    }
+    *length = required;
+    return 0;
+}
+
+LONG SCardConnect(LONG context, const char *reader, DWORD sharing,
+                  DWORD protocols, LONG *card, DWORD *protocol) {
+    if (context != context_handle || strcmp(reader, reader_name) || sharing != 2 || protocols != 3) return -1;
+    *card = card_handle;
+    *protocol = 1;
+    return 0;
+}
+
+LONG SCardDisconnect(LONG card, DWORD disposition) {
+    return card == card_handle && disposition == 0 ? 0 : -1;
+}
+
+LONG SCardBeginTransaction(LONG card) {
+    return card == card_handle ? 0 : -1;
+}
+
+LONG SCardEndTransaction(LONG card, DWORD disposition) {
+    return SCardDisconnect(card, disposition);
+}
+
+LONG SCardStatus(LONG card, char *reader, DWORD *reader_length, DWORD *state,
+                 DWORD *protocol, unsigned char *atr, DWORD *atr_length) {
+    if (card != card_handle || *reader_length != 256 || *atr_length != 64) return -1;
+    memcpy(reader, reader_name, sizeof(reader_name));
+    *reader_length = sizeof(reader_name);
+    *state = 6;
+    *protocol = 1;
+    atr[0] = 0x3B;
+    atr[1] = 0x00;
+    *atr_length = 2;
+    return 0;
+}
+
+LONG SCardGetAttrib(LONG card, DWORD attribute, unsigned char *value, DWORD *length) {
+    if (card != card_handle || attribute != 0x00020110 || *length != 8) return -1;
+    memset(value, 0, 4);
+    *length = 4;
+    return 0;
+}
+
+LONG SCardTransmit(LONG card, const PCI *send_pci, const unsigned char *command,
+                   DWORD command_length, PCI *receive_pci, unsigned char *response,
+                   DWORD *response_length) {
+    if (card != card_handle || send_pci->protocol != 1 || send_pci->length != sizeof(PCI) ||
+        command_length != 4 || command[1] != 0xA4 || receive_pci || *response_length != 65546) return -1;
+    response[0] = 0x90;
+    response[1] = 0x00;
+    *response_length = 2;
+    return 0;
+}


### PR DESCRIPTION
## Problem

The native DWORD/LONG fix already on `main` still represents SCARDCONTEXT/SCARDHANDLE as `uintptr`. These handles are native LONG values: pointer-sized on Linux, but 32-bit in macOS PCSC.framework even on a 64-bit process. Using pointer width for the handle parameters and output pointers leaves the binding inconsistent with the native ABI.

## Changes

- Use the existing platform-specific `pcscLong` alias for context/card handles, including native function signatures and stored handles.
- Keep library handles and reserved native pointers as `uintptr`.
- Add layout/error-code checks and a small C shared-library fixture that exercises reader discovery, connect, status, attributes, transmit and disconnect without hardware.

## Validation

- `GOWORK=off CGO_ENABLED=0 go test -tags 'with_utls nomsgpack' -count=1 ./internal/pcsc -skip '^TestSystemBackendDiscoveryDoesNotPanic$'`
- Linux amd64 application build with `with_utls nomsgpack`.
- PC/SC test-binary cross-compilation for Darwin arm64 and Linux arm64; these cross-compiled binaries were not executed.
- Hardware discovery is excluded because the build user does not have reader access. No real SIM operations are performed.

This is an independent PR against `main`; it does not include PIN policy, SIP/USSD changes, local deployment notes or binaries.
