### PR TITLE
fix(ussi): handle typed-nil SIP messages after INVITE failure

### DIFF
--- a/third_party/vowifi-go/internal/vowifi/ussi/logging.go
+++ b/third_party/vowifi-go/internal/vowifi/ussi/logging.go
@@ -8,7 +8,7 @@ import (
 )
 
 func logUSSISIPRaw(deviceID, phase, direction string, message sip.Message) {
-	if message == nil {
+	if isNilSIPMessage(message) {
 		return
 	}
 	raw := strings.TrimSpace(message.String())
@@ -28,7 +28,7 @@ func logUSSISIPRaw(deviceID, phase, direction string, message sip.Message) {
 }
 
 func ussiSIPRawLogMethodAndCallID(message sip.Message) (string, string) {
-	if message == nil {
+	if isNilSIPMessage(message) {
 		return "", ""
 	}
 	method := ""
@@ -45,6 +45,17 @@ func ussiSIPRawLogMethodAndCallID(message sip.Message) (string, string) {
 		callID = strings.TrimSpace(header.Value())
 	}
 	return method, callID
+}
+
+func isNilSIPMessage(message sip.Message) bool {
+	switch value := message.(type) {
+	case *sip.Request:
+		return value == nil
+	case *sip.Response:
+		return value == nil
+	default:
+		return message == nil
+	}
 }
 
 func (s *Service) logInboundMismatch(phase, reason string, request *sip.Request) {

--- a/third_party/vowifi-go/internal/vowifi/ussi/service.go
+++ b/third_party/vowifi-go/internal/vowifi/ussi/service.go
@@ -41,7 +41,7 @@ func (s *Service) Send(ctx context.Context, command string) (*Result, error) {
 		imsendpoint.ClientInviteOptions{
 			Request: request, Contact: request.Contact(), Timeout: int64(ussiTransactionTimeout),
 		})
-	if invite != nil {
+	if invite != nil && invite.Response != nil {
 		logUSSISIPRaw(s.deviceID, "initial_invite", "recv", invite.Response)
 	}
 	if err != nil {

--- a/third_party/vowifi-go/internal/vowifi/ussi/ussi_test.go
+++ b/third_party/vowifi-go/internal/vowifi/ussi/ussi_test.go
@@ -18,6 +18,42 @@ const (
 	finalText = "Balance: 10"
 )
 
+func TestUSSILogTypedNil(t *testing.T) {
+	for _, message := range []sip.Message{nil, (*sip.Request)(nil), (*sip.Response)(nil)} {
+		logUSSISIPRaw("test", "recv", "recv", message)
+		method, callID := ussiSIPRawLogMethodAndCallID(message)
+		if method != "" || callID != "" {
+			t.Fatalf("nil message metadata = %q %q", method, callID)
+		}
+	}
+}
+
+type failedInviteEndpoint struct {
+	*fakeEndpoint
+	cause error
+}
+
+func (endpoint *failedInviteEndpoint) StartClientInvite(context.Context, string, imsendpoint.ClientInviteOptions) (*imsendpoint.ClientInviteResult, error) {
+	return &imsendpoint.ClientInviteResult{}, endpoint.cause
+}
+
+func TestSendInviteWithoutResponse(t *testing.T) {
+	for _, cause := range []error{errors.New("SIP stream closed"), nil} {
+		endpoint := &failedInviteEndpoint{fakeEndpoint: newFakeEndpoint(t), cause: cause}
+		service := NewService("dev-1", endpoint)
+		result, err := service.Send(context.Background(), "*100#")
+		if err == nil || result == nil || result.Status != 2 {
+			t.Fatalf("result=%+v err=%v", result, err)
+		}
+		if cause != nil && !errors.Is(err, cause) {
+			t.Fatalf("lost original failure: %v", err)
+		}
+		if service.ActiveSessionID() != "" {
+			t.Fatal("failed session still active")
+		}
+	}
+}
+
 func TestRecoveredTypeLayouts(t *testing.T) {
 	assertFields(t, reflect.TypeOf(Context{}), []string{
 		"LocalIP", "LocalPortC", "LocalPortS", "Transport", "Domain", "Realm", "AOR",


### PR DESCRIPTION
## Problem

When an IMS INVITE fails after the SIP stream closes, `StartClientInvite` can return a non-nil result with a nil `Response`. Passing that typed-nil response as `sip.Message` makes `message == nil` false. Logging then calls `Response.String()` on a nil receiver, causing a panic and HTTP 500 instead of returning the transaction error.

## Changes

- Check that an INVITE response exists before logging it.
- Handle typed-nil requests and responses in raw SIP logging and metadata extraction.
- Regress both failed INVITEs and unexpectedly empty successful results: return a normal failure, retain the original error when present and clear the active USSD session.

## Validation

`GOWORK=off CGO_ENABLED=0 go test -tags 'with_utls nomsgpack' -count=1 github.com/iniwex5/vowifi-go/internal/vowifi/ussi`

Linux amd64 application build with `with_utls nomsgpack`.

All tests use fake endpoints. This fixes the error-reporting panic, not the cause of an underlying registration or transaction failure. It is independently based on `main` and does not depend on the separate SIP service-URN compatibility fix.
