### PR TITLE
fix(pcsc): persist reader SIM identity without requiring IMEI

### DIFF
--- a/internal/device/phone_number_sync_test.go
+++ b/internal/device/phone_number_sync_test.go
@@ -2,12 +2,14 @@ package device
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 
-	"github.com/yibaiba/hideck/internal/backend"
-	"github.com/yibaiba/hideck/internal/db"
 	"github.com/iniwex5/vowifi-go/runtimehost/eventhost"
+	"github.com/yibaiba/hideck/internal/backend"
+	"github.com/yibaiba/hideck/internal/config"
+	"github.com/yibaiba/hideck/internal/db"
 )
 
 type workerPhoneBackendStub struct {
@@ -73,6 +75,63 @@ func loadDeviceTestSIMSubscriptionByIMSI(t *testing.T, imsi string) db.SIMSubscr
 		t.Fatalf("First(subscription) error=%v", err)
 	}
 	return sub
+}
+
+func TestPersistPCSCIdentityWithoutModemRecord(test *testing.T) {
+	for _, configured := range []bool{false, true} {
+		for _, imei := range []string{"", "stale-modem-imei"} {
+			test.Run(fmt.Sprintf("configured=%t/imei=%s", configured, imei), func(test *testing.T) {
+				initDevicePhoneNumberTestDB(test)
+				pool := NewPool(nil)
+				worker := &Worker{ID: "reader-1"}
+				if configured {
+					worker.Config = config.DeviceConfig{DeviceBackend: backend.BackendPCSC}
+				} else {
+					worker.Backend = &workerPhoneBackendStub{workerStatusBackendStub: workerStatusBackendStub{mode: backend.BackendPCSC}}
+				}
+				worker.state.Identity.IMEI = imei
+				worker.state.Identity.ICCID = "8986000000000000099"
+				worker.state.Identity.IMSI = "pcsc-imsi"
+				worker.state.Runtime.Operator = "Test operator"
+				previousIMEI := "previous-modem"
+				if err := db.UpsertSIMCard(worker.state.Identity.ICCID, "old-imsi", "", "old operator", &previousIMEI); err != nil {
+					test.Fatal(err)
+				}
+				for attempt := 0; attempt < 2; attempt++ {
+					pool.PersistRuntimeState(worker)
+					pool.PersistIdentityState(worker)
+				}
+				sim := loadDeviceTestSIMCardByIMSI(test, "pcsc-imsi")
+				if sim.ICCID != worker.state.Identity.ICCID || sim.Operator != "Test operator" || sim.CurrentIMEI != nil {
+					test.Fatalf("unexpected SIM identity: %+v", sim)
+				}
+				subscription := loadDeviceTestSIMSubscriptionByIMSI(test, "pcsc-imsi")
+				if subscription.CurrentICCID != sim.ICCID {
+					test.Fatal("SIM subscription identity was not persisted")
+				}
+				var count int64
+				if err := db.DB.Model(&db.Device{}).Count(&count).Error; err != nil || count != 0 {
+					test.Fatalf("reader created a modem record: count=%d err=%v", count, err)
+				}
+			})
+		}
+	}
+}
+
+func TestPersistModemStillRequiresIMEI(test *testing.T) {
+	initDevicePhoneNumberTestDB(test)
+	pool := NewPool(nil)
+	worker := &Worker{ID: "modem", Backend: &workerPhoneBackendStub{workerStatusBackendStub: workerStatusBackendStub{mode: backend.BackendQMI}}}
+	worker.state.Identity.ICCID = "8986000000000000099"
+	worker.state.Identity.IMSI = "modem-imsi"
+	pool.PersistRuntimeState(worker)
+	pool.PersistIdentityState(worker)
+	for _, model := range []any{&db.Device{}, &db.SIMCard{}} {
+		var count int64
+		if err := db.DB.Model(model).Count(&count).Error; err != nil || count != 0 {
+			test.Fatalf("persisted modem without IMEI: count=%d err=%v", count, err)
+		}
+	}
 }
 
 func TestPersistIdentityStateStoresQMIMSISDNAsModemPhoneNumber(t *testing.T) {

--- a/internal/device/pool.go
+++ b/internal/device/pool.go
@@ -2548,6 +2548,9 @@ func (p *Pool) PersistRuntimeState(worker *Worker) {
 	if worker == nil {
 		return
 	}
+	if resolvedBackendMode(worker.Config) == backend.BackendPCSC || (worker.Backend != nil && worker.Backend.Mode() == backend.BackendPCSC) {
+		return
+	}
 
 	status := worker.ProjectDeviceStatus()
 	imei := strings.TrimSpace(status.IMEI)
@@ -2576,6 +2579,13 @@ func (p *Pool) PersistIdentityState(worker *Worker) {
 	}
 	imei := strings.TrimSpace(status.IMEI)
 	operator := strings.TrimSpace(status.Operator)
+
+	if resolvedBackendMode(worker.Config) == backend.BackendPCSC || (worker.Backend != nil && worker.Backend.Mode() == backend.BackendPCSC) {
+		if err := db.UpsertSIMCard(iccid, imsi, "", operator, nil); err != nil {
+			logger.Warn(fmt.Sprintf("[%s] 更新 SIM 卡信息失败", worker.ID), "err", err)
+		}
+		return
+	}
 
 	if imei == "" {
 		logger.Warn(fmt.Sprintf("[%s] 无法同步设备 SIM 身份：IMEI 为空", worker.ID))


### PR DESCRIPTION
## Problem

PC/SC reader workers do not supply a modem IMEI. The shared persistence path nevertheless warns repeatedly that IMEI is empty and returns before saving the SIM identity/subscription.

## Changes

- Skip IMEI-keyed modem Device persistence for PC/SC workers.
- Persist their SIM identity using the existing nullable IMEI relationship; do not invent an IMEI or substitute ICCID as one.
- Keep missing-IMEI checks unchanged for cellular modem workers.
- Cover configured PC/SC workers and detected backends, empty/stale IMEIs, repeated persistence, clearing an old SIM-to-IMEI association and saving subscription identity without creating a modem record.

## Validation

`GOWORK=off CGO_ENABLED=0 go test -tags 'with_utls nomsgpack' -count=1 ./internal/device ./internal/api`

Linux amd64 application build with `with_utls nomsgpack`.

Tests use a temporary SQLite database and fake workers. Only two existing files change; no schema changes or new source/documentation files. This PR is independent of the PC/SC ABI and PIN-safety fixes.
