### PR TITLE
fix(ims): parse service URNs in SIP address headers without a dependency fork

### DIFF
--- a/third_party/vowifi-go/internal/vowifi/imscore/sip_parser.go
+++ b/third_party/vowifi-go/internal/vowifi/imscore/sip_parser.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"strings"
 
 	"github.com/emiago/sipgo/sip"
@@ -101,7 +102,79 @@ func sipHeaderContinuation(data []byte, offset int) (int, bool) {
 }
 
 func parseSIPMessage(raw string) (sip.Message, error) {
-	return sip.NewParser().ParseSIP(unfoldSIPHeaders([]byte(raw)))
+	return newSIPParser().ParseSIP(unfoldSIPHeaders([]byte(raw)))
+}
+
+func newSIPParser() *sip.Parser {
+	parsers := maps.Clone(sip.DefaultHeadersParser())
+	for _, name := range []string{"to", "t", "from", "f", "contact", "m", "route", "record-route", "refer-to", "referred-by"} {
+		base := parsers[name]
+		parsers[name] = func(headerName []byte, value string) (sip.Header, error) {
+			start, end := sipAddressSpan(value)
+			address := value[start:end]
+			if !strings.HasPrefix(strings.ToLower(address), "urn:service:") {
+				return base(headerName, value)
+			}
+			if err := sipkit.ParseURI(address); err != nil {
+				return nil, err
+			}
+			masked := value[:start] + "sip:" + strings.Repeat("x", len(address)-4) + value[end:]
+			header, err := base(headerName, masked)
+			uri := sip.Uri{Scheme: "urn", Host: address[len("urn:"):]}
+			switch typed := header.(type) {
+			case *sip.ToHeader:
+				typed.Address = uri
+			case *sip.FromHeader:
+				typed.Address = uri
+			case *sip.ContactHeader:
+				typed.Address = uri
+			case *sip.RouteHeader:
+				typed.Address = uri
+			case *sip.RecordRouteHeader:
+				typed.Address = uri
+			case *sip.ReferToHeader:
+				typed.Address = uri
+			case *sip.ReferredByHeader:
+				typed.Address = uri
+			}
+			return header, err
+		}
+	}
+	return sip.NewParser(sip.WithHeadersParsers(parsers))
+}
+
+func sipAddressSpan(value string) (int, int) {
+	quoted, escaped := false, false
+	for index, character := range value {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if quoted && character == '\\' {
+			escaped = true
+			continue
+		}
+		if character == '"' {
+			quoted = !quoted
+		}
+		if quoted {
+			continue
+		}
+		if character == '<' {
+			if end := strings.IndexByte(value[index+1:], '>'); end >= 0 {
+				return index + 1, index + 1 + end
+			}
+			return 0, 0
+		}
+		if character == ',' {
+			break
+		}
+	}
+	start := len(value) - len(strings.TrimLeft(value, " \t"))
+	if end := strings.IndexAny(value[start:], ";, \t"); end >= 0 {
+		return start, start + end
+	}
+	return start, len(value)
 }
 
 func parseSIPResponse(raw string) (*sipResponse, error) {
@@ -196,7 +269,7 @@ func readSIPStreamFrame(reader *bufio.Reader, keepalive io.Writer, onPong func()
 		return nil, "", err
 	}
 	unfolded := unfoldSIPHeaders(header)
-	message, _, err := sip.NewParser().ParseHeaders(unfolded, true)
+	message, _, err := newSIPParser().ParseHeaders(unfolded, true)
 	if err != nil {
 		if errors.Is(err, sip.ErrParseReadBodyIncomplete) {
 			return nil, "", fmt.Errorf("%w: %s", err, summarizeSIPHeaderFrame(unfolded))

--- a/third_party/vowifi-go/internal/vowifi/imscore/sip_parser_test.go
+++ b/third_party/vowifi-go/internal/vowifi/imscore/sip_parser_test.go
@@ -13,6 +13,94 @@ import (
 	"github.com/emiago/sipgo/sip"
 )
 
+func TestSIPStreamServiceURN(t *testing.T) {
+	wire := "SIP/2.0 380 Alternative Service\r\nVia: SIP/2.0/TCP [2001:db8::1]:5060;branch=z9hG4bKurn\r\nFrom: <sip:user@ims.example>;tag=local\r\nTo: <urn:service:sos>;tag=remote\r\nContact: <urn:service:sos>\r\nCall-ID: urn-test\r\nCSeq: 1 INVITE\r\nContent-Length: 0\r\n\r\n"
+	message, err := parseSIPMessage(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if message.To().Address.String() != "urn:service:sos" {
+		t.Fatalf("To URI changed: %s", message.To().Address.String())
+	}
+	decoder := newSIPStreamDecoder(strings.NewReader(wire + wire))
+	defer decoder.Close()
+	for count := 0; count < 2; count++ {
+		message, err := decoder.ReadMessage()
+		if err != nil {
+			t.Fatal(err)
+		}
+		response, ok := message.(*sip.Response)
+		if !ok || response.StatusCode != 380 || response.Contact().Address.String() != "urn:service:sos" {
+			t.Fatalf("unexpected response: %v", message)
+		}
+	}
+	if _, err := decoder.ReadMessage(); err != io.EOF {
+		t.Fatalf("stream boundary lost: %v", err)
+	}
+}
+
+func TestServiceURNHeaderCompatibility(test *testing.T) {
+	for _, name := range []string{"To", "t", "From", "f", "Contact", "m", "Route", "Record-Route", "Refer-To", "Referred-By"} {
+		test.Run(name, func(test *testing.T) {
+			wire := "SIP/2.0 380 Alternative Service\r\n" + name + ": <urn:service:sos.police>\r\nContent-Length: 0\r\n\r\n"
+			message, err := parseSIPMessage(wire)
+			if err != nil {
+				test.Fatal(err)
+			}
+			if got := message.(*sip.Response).Headers()[0].Value(); got != "<urn:service:sos.police>" {
+				test.Fatalf("header changed: %q", got)
+			}
+		})
+	}
+}
+
+func TestServiceURNPreservesHeaderListsAndBody(test *testing.T) {
+	body := "<ussd>urn:service:sos</ussd>"
+	for _, contacts := range []string{
+		`<urn:service:sos>;expires=60, <sip:user@[2001:db8::1]:5060>;expires=30`,
+		`<sip:user@[2001:db8::1]:5060>;expires=30, <urn:service:sos>;expires=60`,
+		"<urn:service:sos>;expires=60,\r\n\t<urn:service:sos.police>;expires=30",
+	} {
+		wire := "SIP/2.0 380 Alternative Service\r\nTo: urn:service:sos;tag=remote\r\nContact: " + contacts + "\r\nContent-Length: " + fmt.Sprint(len(body)) + "\r\n\r\n" + body
+		message, err := parseSIPMessage(wire)
+		if err != nil {
+			test.Fatal(err)
+		}
+		if string(message.Body()) != body || message.To().Params.ToString(';') != "tag=remote" {
+			test.Fatal("body or header parameters changed")
+		}
+		headers := message.GetHeaders("Contact")
+		if len(headers) != 2 {
+			test.Fatalf("got %d contacts", len(headers))
+		}
+		for index, value := range strings.Split(contacts, ",") {
+			if headers[index].Value() != strings.TrimSpace(value) {
+				test.Fatalf("contact %d changed: %q", index, headers[index].Value())
+			}
+		}
+	}
+}
+
+func TestServiceURNCompatibilityRemainsLocal(test *testing.T) {
+	for _, value := range []string{"urn:service:", "urn:service:so s", "urn:service:sos..police", "sip:ims.example:sos"} {
+		if _, err := parseSIPMessage("SIP/2.0 380 Alternative Service\r\nTo: <" + value + ">\r\nContent-Length: 0\r\n\r\n"); err == nil {
+			test.Fatalf("accepted malformed URI %q", value)
+		}
+	}
+	wire := "SIP/2.0 380 Alternative Service\r\nTo: <urn:service:sos>\r\nContent-Length: 0\r\n\r\n"
+	if _, err := parseSIPMessage(wire); err != nil {
+		test.Fatal(err)
+	}
+	if _, err := sip.NewParser().ParseSIP([]byte(wire)); err == nil {
+		test.Fatal("compatibility parser modified sipgo global parsers")
+	}
+	value := `"<urn:service:sos>" <sip:user@ims.example>;tag=remote`
+	message, err := parseSIPMessage("SIP/2.0 200 OK\r\nTo: " + value + "\r\nContent-Length: 0\r\n\r\n")
+	if err != nil || message.To().Address.String() != "sip:user@ims.example" {
+		test.Fatalf("quoted display name treated as URI: %v", err)
+	}
+}
+
 func TestSIPParserAcceptsBuiltRegisterAndResponse(t *testing.T) {
 	service := &Service{cfg: &IMSConfig{
 		IMSI: "234102356143376", IMPI: "234102356143376@ims.example",

--- a/third_party/vowifi-go/internal/vowifi/sipkit/uri.go
+++ b/third_party/vowifi-go/internal/vowifi/sipkit/uri.go
@@ -3,11 +3,14 @@ package sipkit
 import (
 	"errors"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/emiago/sipgo/sip"
 )
+
+var serviceURNPattern = regexp.MustCompile(`(?i)^urn:service:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)*$`)
 
 // ParseURI validates a SIP, SIPS, TEL, or URN URI.
 func ParseURI(value string) error {
@@ -153,6 +156,12 @@ func hasURIScheme(value string) bool {
 
 func parseURIValue(value string) (*sip.Uri, error) {
 	value = strings.TrimSpace(value)
+	if strings.HasPrefix(strings.ToLower(value), "urn:service:") {
+		if !serviceURNPattern.MatchString(value) {
+			return nil, errors.New("invalid service URN")
+		}
+		return &sip.Uri{Scheme: "urn", Host: value[len("urn:"):]}, nil
+	}
 	if !hasURIScheme(value) {
 		value = "sip:" + value
 	}

--- a/third_party/vowifi-go/internal/vowifi/sipkit/uri_test.go
+++ b/third_party/vowifi-go/internal/vowifi/sipkit/uri_test.go
@@ -3,13 +3,13 @@ package sipkit
 import "testing"
 
 func TestParseURIValidation(t *testing.T) {
-	valid := []string{"sip:user@example.com", "user@example.com", "tel:+441234", "sip:"}
+	valid := []string{"sip:user@example.com", "user@example.com", "tel:+441234", "sip:", "urn:service:sos", "URN:service:sos.police"}
 	for _, value := range valid {
 		if err := ParseURI(value); err != nil {
 			t.Errorf("ParseURI(%q): %v", value, err)
 		}
 	}
-	for _, value := range []string{"", "tel:   ", "urn:service:sos"} {
+	for _, value := range []string{"", "tel:   ", "urn:service:", "urn:service:so s", "urn:service:sos..police", "urn:service:sos:5060"} {
 		if err := ParseURI(value); err == nil {
 			t.Errorf("ParseURI(%q) succeeded", value)
 		}


### PR DESCRIPTION
## Problem

The IMS registration stream can abort with `strconv.Atoi: parsing "sos": invalid syntax`. A SIP response containing `urn:service:sos` in an address header reproduces this with sipgo v1.4.0, whose URI parser interprets the final colon as a SIP port separator. The original operator packet is not available, so the precise field in that packet is not confirmed.

## Changes

- Add a local IMS parser using sipgo's existing header-parser hooks; do not vendor, replace or upgrade the dependency.
- Validate service URNs and retain structured address headers, display names and header parameters.
- Use a same-length temporary SIP address only inside the underlying header parser, then restore the service URN before returning. This preserves comma offsets for multi-value headers; serialized messages retain the original service URI rather than the temporary address.
- Clone the parser map rather than modifying sipgo's global parser configuration.
- Test compact header names, folded/mixed contact lists, quoted display names, unchanged bodies, consecutive stream frames and malformed addresses.

Scope is service URNs in IMS **address headers**, not arbitrary URN namespaces or new emergency-call/request-URI support.

## Validation

Focused parser/URN regressions pass:

`GOWORK=off CGO_ENABLED=0 go test -tags 'with_utls nomsgpack' -count=1 github.com/iniwex5/vowifi-go/internal/vowifi/imscore github.com/iniwex5/vowifi-go/internal/vowifi/sipkit -run 'TestServiceURN|TestSIPStreamServiceURN|TestSIPParser|TestParseSIP|TestReadSIP|TestParseURIValidation'`

The broader IMS/sipkit suites pass with the following exclusions:

`GOWORK=off CGO_ENABLED=0 go test -tags 'with_utls nomsgpack' -count=1 github.com/iniwex5/vowifi-go/internal/vowifi/imscore github.com/iniwex5/vowifi-go/internal/vowifi/sipkit -skip '^(TestIPSec3GPPListenerAppliesTCPMSS|TestProtectedRegistrationResetRequestsFreshRuntime|TestProtectedUDPShutdownWhileRegisterLockHeld)$'`

Linux amd64 application build with `with_utls nomsgpack`.

Test limitations: the existing TCP MSS test is excluded because this host reports MSS 1088 rather than the expected 1100, including with the unmodified parser. A broader run also failed `TestProtectedRegistrationResetRequestsFreshRuntime` with a broken-pipe error instead of its expected stream-close error; a rerun timed out in `TestProtectedUDPShutdownWhileRegisterLockHeld`. Both lifecycle tests passed when run alone five times against unchanged IMS source. The unfiltered suite is therefore **not claimed to pass**; these tests were not changed as part of this parser fix. No real carrier call/USSD was initiated for validation.

Independent PR against `main`; no PC/SC, USSD nil-response, documentation or binary changes.
