### PR TITLE
fix(vowifi): base health on operational IMS readiness

### DIFF
--- a/internal/vowifihost/health.go
+++ b/internal/vowifihost/health.go
@@ -140,7 +140,7 @@ func (s *wifiCallingHealthStore) Observe(deviceID string, state runtimehost.Stat
 			session.currentReason = healthReason(state)
 			return
 		}
-		session.start(at, healthReason(state))
+		session.start(at, healthStartReason(state))
 		return
 	}
 	session.transition(healthState(state), at, healthReason(state))
@@ -214,7 +214,7 @@ func (s *wifiCallingHealthSession) start(at time.Time, reason string) {
 	s.currentReason = ""
 	s.currentStartedAt = at
 	if strings.TrimSpace(reason) == "" {
-		reason = "IMS SMS receiver ready"
+		reason = "WiFi Calling ready"
 	}
 	s.appendEvent("started", "healthy", at, reason)
 }
@@ -372,18 +372,24 @@ func healthState(state runtimehost.State) string {
 }
 
 func wifiCallingReady(state runtimehost.State) bool {
-	return state.SMSHealthReady || (state.IMSReady && state.SMSReady)
+	return state.IMSReady || state.SMSHealthReady
+}
+
+func healthStartReason(state runtimehost.State) string {
+	if state.IMSReady {
+		return "IMS registered"
+	}
+	if state.SMSHealthReady {
+		return "IMS runtime health ready"
+	}
+	return ""
 }
 
 func healthReason(state runtimehost.State) string {
-	if state.SMSHealthReady && !state.SMSReady {
+	if wifiCallingReady(state) {
 		return ""
 	}
-	values := []string{state.LastError, state.LastReason}
-	if state.IMSReady || state.SMSHealthReady {
-		values = []string{state.SMSReadyReason, state.LastError, state.LastReason}
-	}
-	values = append(values, state.Phase)
+	values := []string{state.LastError, state.LastReason, state.SMSReadyReason, state.Phase}
 	for _, value := range values {
 		if value = strings.TrimSpace(value); value != "" {
 			return value

--- a/internal/vowifihost/health_test.go
+++ b/internal/vowifihost/health_test.go
@@ -87,7 +87,7 @@ func TestWiFiCallingHealthNewSessionDoesNotAccumulatePriorEvents(t *testing.T) {
 	}
 }
 
-func TestWiFiCallingHealthMeasuresPortSOutageFromSMSReadiness(t *testing.T) {
+func TestWiFiCallingHealthDoesNotCountSMSReceiverReadinessAsIMSOutage(t *testing.T) {
 	store := newWiFiCallingHealthStore()
 	started := time.Date(2026, 9, 4, 10, 0, 0, 0, time.UTC)
 	observeHealth(store, started, true, "ims_ready", "")
@@ -101,21 +101,18 @@ func TestWiFiCallingHealthMeasuresPortSOutageFromSMSReadiness(t *testing.T) {
 	})
 
 	snapshot, _ := store.Snapshot("wwan0", started.Add(2*time.Minute))
-	if snapshot.State != "healthy" || snapshot.InterruptionCount != 1 {
-		t.Fatalf("port-s outage was not recorded: %+v", snapshot)
+	if snapshot.State != "healthy" || snapshot.InterruptionCount != 0 {
+		t.Fatalf("SMS receiver readiness changed IMS health: %+v", snapshot)
 	}
-	if snapshot.InterruptedSeconds != 30 || snapshot.Availability != 75 {
-		t.Fatalf("port-s outage duration = %+v", snapshot)
+	if snapshot.InterruptedSeconds != 0 || snapshot.Availability != 100 {
+		t.Fatalf("SMS receiver readiness reduced IMS availability: %+v", snapshot)
 	}
-	if got := snapshot.Events[1]; got.Kind != "interrupted" || got.Reason != "IMS SMS receiver is not ready" {
-		t.Fatalf("port-s interruption event = %+v", got)
-	}
-	if got := snapshot.Events[2]; got.Kind != "recovered" || got.At != started.Add(90*time.Second) {
-		t.Fatalf("port-s recovery event = %+v", got)
+	if len(snapshot.Events) != 1 || snapshot.Events[0].Kind != "started" {
+		t.Fatalf("SMS receiver readiness created health events: %+v", snapshot.Events)
 	}
 }
 
-func TestWiFiCallingHealthStartsWhenSMSReceiverIsReady(t *testing.T) {
+func TestWiFiCallingHealthStartsWhenIMSIsRegistered(t *testing.T) {
 	store := newWiFiCallingHealthStore()
 	started := time.Date(2026, 9, 4, 10, 30, 0, 0, time.UTC)
 	store.Begin("wwan0", started)
@@ -124,9 +121,15 @@ func TestWiFiCallingHealthStartsWhenSMSReceiverIsReady(t *testing.T) {
 		SMSReadyReason: "IMS SMS receiver is not ready", UpdatedAt: started.Add(time.Second),
 	})
 
-	checking, _ := store.Snapshot("wwan0", started.Add(2*time.Second))
-	if checking.Measured || checking.State != "checking" {
-		t.Fatalf("IMS-only readiness started health measurement: %+v", checking)
+	registered, _ := store.Snapshot("wwan0", started.Add(2*time.Second))
+	if !registered.Measured || registered.State != "healthy" {
+		t.Fatalf("IMS registration did not start health measurement: %+v", registered)
+	}
+	if registered.SessionStartedAt != started.Add(time.Second) {
+		t.Fatalf("session started at %v, want first IMS registration", registered.SessionStartedAt)
+	}
+	if got := registered.Events[0]; got.Kind != "started" || got.Reason != "IMS registered" {
+		t.Fatalf("start event = %+v", got)
 	}
 
 	store.Observe("wwan0", runtimehost.State{
@@ -134,11 +137,11 @@ func TestWiFiCallingHealthStartsWhenSMSReceiverIsReady(t *testing.T) {
 		SMSReadyReason: "IMS SMS receiver ready", UpdatedAt: started.Add(3 * time.Second),
 	})
 	snapshot, _ := store.Snapshot("wwan0", started.Add(4*time.Second))
-	if !snapshot.Measured || snapshot.SessionStartedAt != started.Add(3*time.Second) {
-		t.Fatalf("SMS readiness did not start health measurement: %+v", snapshot)
+	if !snapshot.Measured || snapshot.SessionStartedAt != started.Add(time.Second) {
+		t.Fatalf("SMS readiness restarted health measurement: %+v", snapshot)
 	}
-	if got := snapshot.Events[0]; got.Kind != "started" || got.Reason != "IMS SMS receiver ready" {
-		t.Fatalf("start event = %+v", got)
+	if len(snapshot.Events) != 1 {
+		t.Fatalf("SMS readiness created health events: %+v", snapshot.Events)
 	}
 }
 
@@ -153,6 +156,9 @@ func TestWiFiCallingHealthStartsFromEarlyRuntimeHealthReadiness(t *testing.T) {
 	snapshot, _ := store.Snapshot("wwan0", started.Add(2*time.Second))
 	if !snapshot.Measured || snapshot.SessionStartedAt != started.Add(time.Second) {
 		t.Fatalf("early health readiness did not start measurement: %+v", snapshot)
+	}
+	if got := snapshot.Events[0]; got.Reason != "IMS runtime health ready" {
+		t.Fatalf("early readiness start event = %+v", got)
 	}
 }
 

--- a/web/src/utils/dashboardPresentation.ts
+++ b/web/src/utils/dashboardPresentation.ts
@@ -82,7 +82,7 @@ export function createDashboardStages(
     Object.freeze({ key: 'Access', ready: runtime?.access_ready }),
     Object.freeze({ key: 'Tunnel', ready: runtime?.tunnel_ready }),
     Object.freeze({ key: 'IMS', ready: runtime?.ims_ready }),
-    Object.freeze({ key: 'SMS', ready: runtime?.sms_ready })
+    Object.freeze({ key: 'SMS', ready: runtime?.sms_mo_ready ?? runtime?.sms_ready })
   ])
 }
 

--- a/web/src/utils/overviewConnectionPresentation.ts
+++ b/web/src/utils/overviewConnectionPresentation.ts
@@ -74,11 +74,15 @@ function createVoLTEPresentation(device: DeviceOverviewItem): OverviewConnection
 function createVoWiFiOrCellularPresentation(
   device: DeviceOverviewItem | null
 ): OverviewConnectionPresentation {
-  const stages = createDashboardStages(device?.vowifi_runtime)
+  const runtime = device?.vowifi_runtime
+  const stages = createDashboardStages(runtime)
   const hasFailedStage = stages.some((stage) => stage.ready === false)
   const hasReadyStage = stages.some((stage) => stage.ready === true)
   const allStagesReady = stages.every((stage) => stage.ready === true)
-  const runtimeReason = device?.vowifi_runtime?.sms_ready_reason || device?.vowifi_runtime?.last_reason || ''
+  const smsOperational = runtime?.sms_mo_ready ?? runtime?.sms_ready
+  const runtimeReason = runtime?.last_reason
+    || (smsOperational === false ? runtime?.sms_ready_reason : '')
+    || ''
   const protocol = metric(t('devices.protocol'), device?.backend_mode?.toUpperCase())
   const deviceInterface = metric(t('devices.iface'), device?.interface)
 
@@ -138,7 +142,6 @@ function createVoWiFiOrCellularPresentation(
     detail = runtimeReason || t('overview.waitStages')
   }
 
-  const runtime = device.vowifi_runtime
   return Object.freeze({
     kind: 'wifi',
     eyebrow: 'WI-FI CALLING',
@@ -152,7 +155,7 @@ function createVoWiFiOrCellularPresentation(
       metric(t('overview.dataplane'), runtime?.dataplane_mode),
       protocol,
       deviceInterface,
-      metric(t('overview.lastReason'), runtime?.last_reason || runtime?.sms_ready_reason, t('common.none')),
+      metric(t('overview.lastReason'), runtimeReason, t('common.none')),
       metric(t('overview.errorClass'), runtime?.last_error_class, t('common.none'))
     ])
   })

--- a/web/tests/dashboardPresentation.test.ts
+++ b/web/tests/dashboardPresentation.test.ts
@@ -175,6 +175,26 @@ test('animates the service path only for active VoWiFi without failed stages', (
   assert.equal(canAnimateDashboardConnection(createDevice({ vowifi_active: false })), false)
 })
 
+test('uses outbound SMS readiness when the optional receiver path is unavailable', () => {
+  const device = createDevice({
+    vowifi_active: true,
+    vowifi_runtime: {
+      sim_ready: true,
+      access_ready: true,
+      tunnel_ready: true,
+      ims_ready: true,
+      sms_ready: false,
+      sms_mo_ready: true,
+      sms_ready_reason: 'IMS SMS receiver is not ready'
+    }
+  })
+
+  const presentation = createDashboardDevicePresentation(device)
+
+  assert.deepEqual(presentation.stages.map(stage => stage.ready), [true, true, true, true, true])
+  assert.equal(canAnimateDashboardConnection(device), true)
+})
+
 test('formats cellular connection and validates signal sentinels', () => {
   const presentation = createDashboardDevicePresentation(createDevice())
 

--- a/web/tests/overviewConnectionPresentation.test.ts
+++ b/web/tests/overviewConnectionPresentation.test.ts
@@ -86,6 +86,31 @@ test('wifi calling presentation stays on the ePDG path', () => {
   assert.equal(presentation.metrics.find((item) => item.label === '接入方式')?.value, 'Wi-Fi Calling')
 })
 
+test('wifi calling stays healthy when SMS is send-ready without the optional receiver path', () => {
+  const presentation = createOverviewConnectionPresentation(device({
+    phone_mode: 'wifi',
+    vowifi_enabled: true,
+    vowifi_active: true,
+    vowifi_runtime: {
+      sim_ready: true,
+      access_ready: true,
+      tunnel_ready: true,
+      ims_ready: true,
+      sms_ready: false,
+      sms_mo_ready: true,
+      sms_ready_reason: 'IMS SMS receiver is not ready'
+    }
+  }))
+
+  assert.equal(presentation.title, 'VoWiFi 已连接')
+  assert.equal(presentation.tone, 'is-ready')
+  assert.equal(presentation.pathIsFlowing, true)
+  assert.deepEqual(presentation.stages.map((stage) => stage.ready), [true, true, true, true, true])
+  assert.equal(
+    presentation.metrics.some((item) => item.value === 'IMS SMS receiver is not ready'), false
+  )
+})
+
 test('wifi calling stays on the wifi path when the service is off', () => {
   const presentation = createOverviewConnectionPresentation(device({
     phone_mode: 'wifi',


### PR DESCRIPTION
## Summary

Fix the false VoWiFi outage shown when IMS voice and SMS work but the optional protected Port-S SMS receiver is not reported ready.

Fixes #19.

## Problem

Some carrier profiles can reach this valid operational state:

```text
IMSReady=true
SMSMOReady=true
SMSReady=false
SMSHealthReady=false
```

Calls and inbound/outbound SMS continue to work through the registered/UDP IMS flow, but the health store never starts because it requires full receiver readiness. The dashboard also treats `sms_ready=false` as a failed connection stage and exposes `IMS SMS receiver is not ready` as the overall failure reason.

## Changes

- Start and maintain WiFi Calling health from IMS registration readiness.
- Preserve the existing early `SMSHealthReady` compatibility path.
- Do not count optional receiver readiness transitions as IMS link interruptions.
- Use `sms_mo_ready ?? sms_ready` for the dashboard SMS stage, retaining compatibility with older API payloads.
- Suppress `sms_ready_reason` as the overall link reason when operational SMS readiness is true.
- Add regression coverage for backend health, dashboard stages, and overview presentation.

The lower-level `SMSReady` and `SMSReadyReason` fields remain unchanged and available for receiver diagnostics; this change only prevents that optional capability from marking the entire VoWiFi service unavailable.

## Verification

```text
go test -count=1 ./internal/vowifihost
ok github.com/yibaiba/hideck/internal/vowifihost

./node_modules/.bin/tsx --test \
  tests/dashboardPresentation.test.ts \
  tests/overviewConnectionPresentation.test.ts
19 tests passed, 0 failed

npm run typecheck
passed

git diff --check upstream/main...HEAD
passed
```
